### PR TITLE
Solidity to v0.8.2 and graph-node fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Look for the [HardHat](https://hardhat.org) console.log() output in the `yarn ch
 ![image](https://user-images.githubusercontent.com/2653167/93150263-dae25180-f6b5-11ea-94e1-b24ab2a63fa5.png)
 
 
-🚽 UNDERFLOW!?! (🚑 [Solidity >0.8.0](https://docs.soliditylang.org/en/v0.8.0/) catchs this [with Checked Arithmetic](https://blog.soliditylang.org/2020/12/16/solidity-v0.8.0-release-announcement/)!
+🚽 UNDERFLOW!?! 🚑 [Solidity >0.8.0](https://docs.soliditylang.org/en/v0.8.0/) catchs this [with Checked Arithmetic](https://blog.soliditylang.org/2020/12/16/solidity-v0.8.0-release-announcement/)!
 
 ![underflow](https://user-images.githubusercontent.com/2653167/93688066-46466d80-fa80-11ea-85df-81fbafa46575.gif)
 

--- a/README.md
+++ b/README.md
@@ -171,17 +171,17 @@ Look for the [HardHat](https://hardhat.org) console.log() output in the `yarn ch
 ![image](https://user-images.githubusercontent.com/2653167/93150263-dae25180-f6b5-11ea-94e1-b24ab2a63fa5.png)
 
 
-🔬  What happens when you subtract 1 from 0? Try it out in the app to see what happens!
+🚽 UNDERFLOW!?! (🚑 [Solidity >0.8.0](https://docs.soliditylang.org/en/v0.8.0/) catchs this [with Checked Arithmetic](https://blog.soliditylang.org/2020/12/16/solidity-v0.8.0-release-announcement/)!
 
 ![underflow](https://user-images.githubusercontent.com/2653167/93688066-46466d80-fa80-11ea-85df-81fbafa46575.gif)
 
-🚽 UNDERFLOW!?! (🚑 [Solidity >0.8.0](https://docs.soliditylang.org/en/v0.8.0/) will catch this!)
+🔬  What happens when you subtract 1 from 0 without this improvement? [Use Solidity 0.7.6](https://hardhat.org/guides/compile-contracts.html#multiple-solidity-versions) and try it out in the app to see what happens! 
 
 🧫 You can iterate and learn as you go. Test your assumptions!
 
 🔐 Global variables like `msg.sender` and `msg.value` are cryptographically backed and can be used to make rules
 
-📝 Keep this [cheat sheet](https://solidity.readthedocs.io/en/v0.7.0/cheatsheet.html?highlight=global#global-variables) handy
+📝 Keep this [cheat sheet](https://solidity.readthedocs.io/en/v0.8.0/cheatsheet.html?highlight=global#global-variables) handy
 
 ⏳ Maybe we could use `block.timestamp` or `block.number` to track time in our contract
 

--- a/docker/graph-node/docker-compose.yml
+++ b/docker/graph-node/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   graph-node:
-    image: graphprotocol/graph-node
+    image: graphprotocol/graph-node:v0.22.0
     ports:
       - '8000:8000'
       - '8001:8001'

--- a/packages/hardhat/hardhat.config.js
+++ b/packages/hardhat/hardhat.config.js
@@ -98,6 +98,15 @@ module.exports = {
   solidity: {
     compilers: [
       {
+        version: "0.8.2",
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 200
+          }
+        }
+      },
+      {
         version: "0.7.6",
         settings: {
           optimizer: {


### PR DESCRIPTION
These are the changes I found myself making to get the project into a state that I wanted to work off. 

1) Pinning `graphprotocol/graph-node` to `v0.22.0`. This eliminates [the CLI issue](https://github.com/graphprotocol/graph-node/issues/2271). It seems that the graph team is aware of it and has pushed a fix but I am still getting the error when trying to start a node using a clean clone of scaffold. I decided that this would make it easier for new users as it seems that there isn't much gained from pointing at the latest version for the target audience of this repo.

2) Add solidity `0.8.2` compiler to hardhat. Based on the breaking changes from `0.7.x` -> `0.8.x`, I feel that a new user would be best set up for success by building habits in `0.8.x`. Things like explicitly casting global address vars as payable could be non-obvious to new developers when they eventually find themselves in `0.8.x` and beyond. I decided to keep `0.7.6` in the config as to not break any solidity built that is specifically scoped to `<=0.7.6`, and as an opportunity to demonstrate the power of hardhat and multiple compiler versions. I've updated the README to reflect this.

I'm a novice with solidity so please let me know if I've missed anything obvious.