### PR TITLE
fix: add required humanize-duration import

### DIFF
--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -99,6 +99,7 @@ const blockExplorer = targetNetwork.blockExplorer;
 const walletLink = new WalletLink({
   appName: "coinbase",
 });
+const humanizeDuration = require("humanize-duration")
 
 // WalletLink provider
 const walletLinkProvider = walletLink.makeWeb3Provider(`https://mainnet.infura.io/v3/${INFURA_ID}`, 1);


### PR DESCRIPTION
This PR fixes a problem in the frontend of the challenge where "humanize-duration" is not instantiated
