### PR TITLE
Update VSCode setting packageDefaultDependenciesDirectory

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-   "solidity.packageDefaultDependenciesDirectory": "packages/hardhat-ts/node_modules",
+   "solidity.packageDefaultDependenciesDirectory": "node_modules/@scaffold-eth/hardhat/node_modules/",
    "solidity-va.test.defaultUnittestTemplate": "hardhat",
    "files.exclude": {
       "**/.git": true,


### PR DESCRIPTION
fix https://github.com/scaffold-eth/scaffold-eth/issues/388
Make the following error go away in VSCode
![image](https://user-images.githubusercontent.com/84996642/133873855-5d97d42c-90f8-49d1-891e-d6b49648be89.png)
