### PR TITLE
updated eth-hooks to 2.3.8: js docs were updated

### DIFF
--- a/packages/react-app/package.json
+++ b/packages/react-app/package.json
@@ -35,7 +35,7 @@
     "axios": "^0.20.0",
     "bnc-notify": "^1.5.0",
     "dotenv": "^8.2.0",
-    "eth-hooks": "2.3.2",
+    "eth-hooks": "2.3.8",
     "ethers": "^5.4.1",
     "fortmatic": "^2.2.1",
     "graphiql": "^1.0.5",


### PR DESCRIPTION
updated eth-hooks
- js docs were updated
- npm package readme has better docs