### PR TITLE
Updated default gasPrice for Avalanche Mainnet

### DIFF
--- a/packages/react-app/src/constants.js
+++ b/packages/react-app/src/constants.js
@@ -165,7 +165,7 @@ export const NETWORKS = {
     chainId: 43114,
     blockExplorer: "https://cchain.explorer.avax.network/",
     rpcUrl: `https://api.avax.network/ext/bc/C/rpc`,
-    gasPrice: 225000000000,
+    gasPrice: 25000000000,
   },
   testnetHarmony: {
     name: "Harmony Testnet",


### PR DESCRIPTION
Last month, Avalanche decreased their gasPrice from 225 gwei to 25 gwei