### PR TITLE
feat: Preserve dollarMode state in localstorage

### DIFF
--- a/packages/react-app/src/components/Balance.jsx
+++ b/packages/react-app/src/components/Balance.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { useBalance } from "eth-hooks";
+import { useLocalStorage } from "../hooks"
 
 const { utils } = require("ethers");
 
@@ -30,7 +31,7 @@ const { utils } = require("ethers");
 */
 
 export default function Balance(props) {
-  const [dollarMode, setDollarMode] = useState(true);
+  const [dollarMode, setDollarMode] = useLocalStorage("dollarMode", true);
 
   // const [listening, setListening] = useState(false);
 


### PR DESCRIPTION
Every hot-reload or page reload, the state of `dollarMode` in the Balance component is reset to `true`, deleting the selection of the user if him selected the bicoin-mode.
The purpose of this feature is to preserve the state saving it in the localStorage.

This serves to avoid manually changing the **currency-mode** each time it is recharged and the user previously selected a **currency mode**.