### PR TITLE
Fix host.docker.internal in graph-node docker for Linux systems

### DIFF
--- a/packages/hardhat/package.json
+++ b/packages/hardhat/package.json
@@ -29,8 +29,8 @@
     "ramda": "^0.27.1"
   },
   "scripts": {
-    "chain": "hardhat node --network hardhat --no-deploy",
-    "fork": "hardhat node --no-deploy --network hardhat --fork https://mainnet.infura.io/v3/460f40a260564ac4a4f4b3fffb032dad",
+    "chain": "hardhat node --network hardhat --no-deploy --hostname 0.0.0.0",
+    "fork": "hardhat node --no-deploy --network hardhat  --hostname 0.0.0.0 --fork https://mainnet.infura.io/v3/460f40a260564ac4a4f4b3fffb032dad",
     "test": "hardhat test --network hardhat",
     "compile": "hardhat compile",
     "deploy": "hardhat deploy --export-all ../react-app/src/contracts/hardhat_contracts.json",

--- a/packages/services/graph-node/README.md
+++ b/packages/services/graph-node/README.md
@@ -35,23 +35,6 @@ to connect to. By default, it will use `mainnet:http://host.docker.internal:8545
 in order to connect to an Ethereum node running on your host machine.
 You can replace this with anything else in `docker-compose.yaml`.
 
-> **Note for Linux users:** On Linux, `host.docker.internal` is not
-> currently supported. Instead, you will have to replace it with the
-> IP address of your Docker host (from the perspective of the Graph
-> Node container).
-> To do this, run:
->
-> ```
-> CONTAINER_ID=$(docker container ls | grep graph-node | cut -d' ' -f1)
-> docker exec $CONTAINER_ID /bin/bash -c 'ip route | awk \'/^default via /{print $3}\''
-> ```
->
-> This will print the host's IP address. Then, put it into `docker-compose.yml`:
->
-> ```
-> sed -i -e 's/host.docker.internal/<IP ADDRESS>/g' docker-compose.yml
-> ```
-
 After you have set up an Ethereum node—e.g. Ganache or Parity—simply
 clone this repository and run
 

--- a/packages/services/graph-node/docker-compose.yml
+++ b/packages/services/graph-node/docker-compose.yml
@@ -19,6 +19,8 @@ services:
       ipfs: "ipfs:5001"
       ethereum: "localhost:http://host.docker.internal:8545"
       GRAPH_LOG: info
+    extra_hosts:
+    - "host.docker.internal:host-gateway"
   ipfs:
     image: ipfs/go-ipfs:v0.4.23
     ports:


### PR DESCRIPTION
In Linux systems, we were experimenting connectivity errors between the chain and the graph-node docker. [Since Docker v20.10 (December 14th 2020)](https://stackoverflow.com/a/43541732) we have this fixed with the [`extra_hosts`](https://docs.docker.com/compose/compose-file/compose-file-v3/#extra_hosts) feature.

The chain also needs to be accessible from the Docker container, so I suggest to set the hostname to `0.0.0.0` by default.