### PR TITLE
feat: Remove change of currency on start application

### DIFF
--- a/packages/react-app/src/components/Balance.jsx
+++ b/packages/react-app/src/components/Balance.jsx
@@ -56,9 +56,9 @@ export default function Balance(props) {
 
   let displayBalance = floatBalance.toFixed(4);
 
-  const price = props.price || props.dollarMultiplier;
+  const price = props.price || props.dollarMultiplier || 1;
 
-  if (price && dollarMode) {
+  if (dollarMode) {
     displayBalance = "$" + (floatBalance * price).toFixed(2);
   }
 


### PR DESCRIPTION
When load application and `dollarMode` is set to `true`, the Balance is shown as eth value for a while and then changes to `dollarMode`.

**Previous behavior:**

Currency and value format changes on start

https://user-images.githubusercontent.com/18385321/136665117-5f7d52e8-18fa-4a8c-b066-275d0730c48a.mp4

**Current Behaviour:**

Currency maintains

* Works fine for dollar mode

https://user-images.githubusercontent.com/18385321/136665128-f753afb8-163f-4df1-968a-362635b10af7.mp4

 
