### PR TITLE
Fixing broken parseEther in React page

### DIFF
--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -484,7 +484,7 @@ function App(props) {
   const [tokenBuyAmount, setTokenBuyAmount] = useState();
 
   const ethCostToPurchaseTokens =
-    tokenBuyAmount && tokensPerEth && parseEther("" + tokenBuyAmount / parseFloat(tokensPerEth));
+    tokenBuyAmount && tokensPerEth && ethers.utils.parseEther("" + tokenBuyAmount / parseFloat(tokensPerEth));
   console.log("ethCostToPurchaseTokens:", ethCostToPurchaseTokens);
 
   const [tokenSendToAddress, setTokenSendToAddress] = useState();


### PR DESCRIPTION
While typing the value eg. `0.1` on main tab in scaffold-eth react app, it breaks the page, because it cannot find parseEther. This one fixes it.