### PR TITLE
Pass `price` prop to `<Contract/>` component

### DIFF
--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -514,6 +514,7 @@ function App(props) {
 
             <Contract
               name="YourContract"
+              price={price}
               signer={userSigner}
               provider={localProvider}
               address={address}


### PR DESCRIPTION
Fixes a bug in the `<Balance/>` component, outlined in [Issue #115](https://github.com/scaffold-eth/scaffold-eth/issues/515) that was preventing the $ dollar value of a contract's balance from being shown.