### PR TITLE
fix: remove OVM configuration from kovanOptimism

### DIFF
--- a/packages/hardhat/hardhat.config.js
+++ b/packages/hardhat/hardhat.config.js
@@ -206,11 +206,9 @@ module.exports = {
     },
     kovanOptimism: {
       url: "https://kovan.optimism.io",
-      gasPrice: 0,
       accounts: {
         mnemonic: mnemonic(),
       },
-      ovm: true,
       companionNetworks: {
         l1: "kovan",
       },


### PR DESCRIPTION
Optimistic Kovan now runs pure EVM so the OVM configuration is no longer required (will actually break if enabled). Gas price can also no longer be zero.