### PR TITLE
allow for readable display of address value when it is a response to …

### DIFF
--- a/packages/react-app/src/components/Contract/DisplayVariable.jsx
+++ b/packages/react-app/src/components/Contract/DisplayVariable.jsx
@@ -1,6 +1,6 @@
 import { Col, Divider, Row } from "antd";
 import React, { useCallback, useEffect, useState } from "react";
-import tryToDisplay from "./utils";
+import { tryToDisplay } from "./utils";
 
 const DisplayVariable = ({ contractFunction, functionInfo, refreshRequired, triggerRefresh }) => {
   const [variable, setVariable] = useState("");

--- a/packages/react-app/src/components/Contract/FunctionForm.jsx
+++ b/packages/react-app/src/components/Contract/FunctionForm.jsx
@@ -2,7 +2,7 @@ import { Button, Col, Divider, Input, Row, Tooltip } from "antd";
 import React, { useState } from "react";
 import Blockies from "react-blockies";
 import { Transactor } from "../../helpers";
-import tryToDisplay from "./utils";
+import { tryToDisplay, tryToDisplayAsText } from "./utils";
 
 const { utils, BigNumber } = require("ethers");
 
@@ -204,7 +204,7 @@ export default function FunctionForm({ contractFunction, functionInfo, provider,
                 try {
                   const returned = await contractFunction(...args);
                   handleForm(returned);
-                  result = tryToDisplay(returned);
+                  result = tryToDisplayAsText(returned);
                 } catch (err) {
                   console.error(err);
                 }

--- a/packages/react-app/src/components/Contract/utils.js
+++ b/packages/react-app/src/components/Contract/utils.js
@@ -3,7 +3,7 @@ import { Address } from "..";
 
 const { utils } = require("ethers");
 
-const tryToDisplay = thing => {
+const tryToDisplay = (thing, asText = false) => {
   if (thing && thing.toNumber) {
     try {
       return thing.toNumber();
@@ -12,9 +12,11 @@ const tryToDisplay = thing => {
     }
   }
   if (thing && thing.indexOf && thing.indexOf("0x") === 0 && thing.length === 42) {
-    return <Address address={thing} fontSize={22} />;
+    return asText ? thing : <Address address={thing} fontSize={22} />;
   }
   return JSON.stringify(thing);
 };
 
-export default tryToDisplay;
+const tryToDisplayAsText = thing => tryToDisplay(thing, true);
+
+export default { tryToDisplay, tryToDisplayAsText };


### PR DESCRIPTION
…a view/pure function call

The FunctionForm displays its result with tryToDisplay(). 

In case of pure/view functions where the response is an address, tryToDisplay() creates an Address component.

Since that is not readable in the FunctionForm, a special handling to display this address value as text can improve the UX.