### PR TITLE
displayvariable: improve readability for bignumbers within arrays/tuples

### DIFF
--- a/packages/react-app/src/components/Contract/utils.js
+++ b/packages/react-app/src/components/Contract/utils.js
@@ -14,7 +14,7 @@ const tryToDisplay = thing => {
   if (thing && thing.indexOf && thing.indexOf("0x") === 0 && thing.length === 42) {
     return <Address address={thing} fontSize={22} />;
   }
-  if (thing.constructor.name == "Array") {
+  if (thing && thing.constructor && thing.constructor.name == "Array") {
     const mostReadable = v => (["number", "boolean"].includes(typeof v) ? v : tryToDisplay(v));
     return JSON.stringify(thing.map(mostReadable));
   }

--- a/packages/react-app/src/components/Contract/utils.js
+++ b/packages/react-app/src/components/Contract/utils.js
@@ -14,6 +14,10 @@ const tryToDisplay = thing => {
   if (thing && thing.indexOf && thing.indexOf("0x") === 0 && thing.length === 42) {
     return <Address address={thing} fontSize={22} />;
   }
+  if (thing.constructor.name == "Array") {
+    const mostReadable = v => (["number", "boolean"].includes(typeof v) ? v : tryToDisplay(v));
+    return JSON.stringify(thing.map(mostReadable));
+  }
   return JSON.stringify(thing);
 };
 


### PR DESCRIPTION
JSON.stringify() on array type response values leaves bignumber object hard to read

ISSUE:
![Screenshot 2021-12-03 at 22 51 57](https://user-images.githubusercontent.com/32189942/144671986-3ae59c4b-84bf-4ef7-b1d6-e054d71c5209.png)

FIX:
![Screenshot 2021-12-03 at 22 52 28](https://user-images.githubusercontent.com/32189942/144672000-2cb67591-0776-41f1-bfc6-1088facbc458.png)


