### PR TITLE
wait a bit before verifying a contract post-deployment

### DIFF
--- a/packages/hardhat/deploy/00_deploy_your_contract.js
+++ b/packages/hardhat/deploy/00_deploy_your_contract.js
@@ -4,6 +4,14 @@ const { ethers } = require("hardhat");
 
 const localChainId = "31337";
 
+const sleep = (ms) =>
+  new Promise((r) =>
+    setTimeout(() => {
+      // console.log(`waited for ${(ms / 1000).toFixed(3)} seconds`);
+      r();
+    }, ms)
+  );
+
 module.exports = async ({ getNamedAccounts, deployments, getChainId }) => {
   const { deploy } = deployments;
   const { deployer } = await getNamedAccounts();
@@ -54,6 +62,8 @@ module.exports = async ({ getNamedAccounts, deployments, getChainId }) => {
   // Verify your contracts with Etherscan
   // You don't want to verify on localhost
   if (chainId !== localChainId) {
+    // wait for etherscan to be ready to verify
+    await sleep(15000);
     await run("verify:verify", {
       address: YourContract.address,
       contract: "contracts/YourContract.sol:YourContract",


### PR DESCRIPTION
The deployment script usually throws an error if we attempt contract verification immediately after deployment. Etherscan has not yet indexed the data, I suppose.
There is a huge error message in the console and the user needs to run the verification separately.

Since deployments on testnet require some waiting anyway, I guess it's acceptable to add a few seconds in order to avoid the issue described.