### PR TITLE
Network UX

### DIFF
--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -53,7 +53,7 @@ const { ethers } = require("ethers");
 */
 
 /// 📡 What chain are your contracts deployed to?
-const targetNetwork = NETWORKS.localhost; // <------- select your target frontend network (localhost, rinkeby, xdai, mainnet)
+const defaultTargetNetwork = NETWORKS.localhost; // <------- select your target frontend network (localhost, rinkeby, xdai, mainnet)
 
 // 😬 Sorry for all the console logging
 const DEBUG = true;
@@ -75,7 +75,10 @@ function App(props) {
 
   const [injectedProvider, setInjectedProvider] = useState();
   const [address, setAddress] = useState();
-  const [selectedNetwork, setSelectedNetwork] = useState(networkOptions[0]);
+  const selectedNetworkOption = networkOptions.includes(defaultTargetNetwork.name)
+    ? defaultTargetNetwork.name
+    : networkOptions[0];
+  const [selectedNetwork, setSelectedNetwork] = useState(selectedNetworkOption);
   const location = useLocation();
 
   /// 📡 What chain are your contracts deployed to?

--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -252,6 +252,7 @@ function App(props) {
         localChainId={localChainId}
         selectedChainId={selectedChainId}
         targetNetwork={targetNetwork}
+        logoutOfWeb3Modal={logoutOfWeb3Modal}
       />
       <Menu style={{ textAlign: "center" }} selectedKeys={[location.pathname]} mode="horizontal">
         <Menu.Item key="/">

--- a/packages/react-app/src/components/NetworkDisplay.jsx
+++ b/packages/react-app/src/components/NetworkDisplay.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { NETWORK } from "../constants";
 import { Alert, Button } from "antd";
 
-function NetworkDisplay({ NETWORKCHECK, localChainId, selectedChainId, targetNetwork }) {
+function NetworkDisplay({ NETWORKCHECK, localChainId, selectedChainId, targetNetwork, logoutOfWeb3Modal }) {
   let networkDisplay = "";
   if (NETWORKCHECK && localChainId && selectedChainId && localChainId !== selectedChainId) {
     const networkSelected = NETWORK(selectedChainId);
@@ -25,11 +25,21 @@ function NetworkDisplay({ NETWORKCHECK, localChainId, selectedChainId, targetNet
         </div>
       );
     } else {
+      const showLogout = networkSelected && networkSelected.name !== "localhost";
       networkDisplay = (
         <div style={{ zIndex: 2, position: "absolute", right: 0, top: 60, padding: 16 }}>
           <Alert
             message="⚠️ Wrong Network"
             description={
+              showLogout
+              ? <div>
+                  You are <b>logged in</b> via Metamask to an external network.
+                  <br/>For local development it is recommended to{" "}
+                  <Button onClick={
+                    logoutOfWeb3Modal
+                  }>logout</Button>
+              </div>
+              :
               <div>
                 You have <b>{networkSelected && networkSelected.name}</b> selected and you need to be on{" "}
                 <Button

--- a/yarn.lock
+++ b/yarn.lock
@@ -8718,10 +8718,10 @@ eth-gas-reporter@^0.2.20:
     sha1 "^1.1.1"
     sync-request "^6.0.0"
 
-eth-hooks@2.3.8:
-  version "2.3.8"
-  resolved "https://registry.yarnpkg.com/eth-hooks/-/eth-hooks-2.3.8.tgz#419246a1f37efd8822813b0f7298399c16f4bba1"
-  integrity sha512-MnmW2LDaUWjdQbHoR1wEHAMu6L9vaRse2Ofs6O43Wu27tn6fZuNPAZVlYSC6D4aD9JYxKZXR7Uz/bkCczJO0pQ==
+eth-hooks@2.3.14:
+  version "2.3.14"
+  resolved "https://registry.yarnpkg.com/eth-hooks/-/eth-hooks-2.3.14.tgz#b1cc495fc36410f67b4b661b5396da4877c50410"
+  integrity sha512-TXADvpC+IwOYy3hQIoeoi8Pxf1Uodqiuz3MCjI06mJcxXrOx8a72mUmaX/XnX+DiuFGbajnlNkbtYj4dZeDa/g==
   dependencies:
     "@ethersproject/address" "^5.4.0"
     "@ethersproject/bignumber" "^5.4.0"


### PR DESCRIPTION
**Improve network switch initialization**
It selects your intended network instead of defaulting to the first option and alerting you in case it doesn't match.

**Improve network mismatch alert** -
If you want to work on localhost but are logged in with an injected provider the alert suggests you switch to localhost. I found some things don't work as expected when working locally via metamask (like switching accounts and having correct balance updates).
So I've added a special handling for this case: It suggest you logout from the injected provider.