### PR TITLE
hardhat.config update 'polytest' to 'mumbai' to match constants.js

### DIFF
--- a/packages/hardhat/hardhat.config.js
+++ b/packages/hardhat/hardhat.config.js
@@ -159,7 +159,7 @@ module.exports = {
         mnemonic: mnemonic(),
       },
     },
-    polytest: {
+    mumbai: {
       url: "https://speedy-nodes-nyc.moralis.io/XXXXXXXXXXXXXXXXXXXXXXX/polygon/mumbai", // <---- YOUR MORALIS ID! (not limited to infura)
       gasPrice: 1000000000,
       accounts: {


### PR DESCRIPTION
Constants.js in react-app does not include "polytest" in NETWORKS.

So when a user deploying with hardhat.config enters "polytest" as defaultNetwork, they may do the same in App.jsx.. which would error.

Just switching it to match constants.js.