### PR TITLE
fix block explorer in contract component

### DIFF
--- a/packages/react-app/src/components/Contract/DisplayVariable.jsx
+++ b/packages/react-app/src/components/Contract/DisplayVariable.jsx
@@ -2,7 +2,7 @@ import { Col, Divider, Row } from "antd";
 import React, { useCallback, useEffect, useState } from "react";
 import { tryToDisplay } from "./utils";
 
-const DisplayVariable = ({ contractFunction, functionInfo, refreshRequired, triggerRefresh }) => {
+const DisplayVariable = ({ contractFunction, functionInfo, refreshRequired, triggerRefresh, blockExplorer }) => {
   const [variable, setVariable] = useState("");
 
   const refresh = useCallback(async () => {
@@ -34,7 +34,7 @@ const DisplayVariable = ({ contractFunction, functionInfo, refreshRequired, trig
           {functionInfo.name}
         </Col>
         <Col span={14}>
-          <h2>{tryToDisplay(variable)}</h2>
+          <h2>{tryToDisplay(variable, false, blockExplorer)}</h2>
         </Col>
         <Col span={2}>
           <h2>

--- a/packages/react-app/src/components/Contract/index.jsx
+++ b/packages/react-app/src/components/Contract/index.jsx
@@ -93,6 +93,7 @@ export default function Contract({
             functionInfo={contractFuncInfo[1]}
             refreshRequired={refreshRequired}
             triggerRefresh={triggerRefresh}
+            blockExplorer={blockExplorer}
           />
         );
       }

--- a/packages/react-app/src/components/Contract/utils.jsx
+++ b/packages/react-app/src/components/Contract/utils.jsx
@@ -3,7 +3,7 @@ import Address from "../Address";
 
 const { utils } = require("ethers");
 
-const tryToDisplay = (thing, asText = false) => {
+const tryToDisplay = (thing, asText = false, blockExplorer) => {
   if (thing && thing.toNumber) {
     try {
       return thing.toNumber();
@@ -13,7 +13,7 @@ const tryToDisplay = (thing, asText = false) => {
     }
   }
   if (thing && thing.indexOf && thing.indexOf("0x") === 0 && thing.length === 42) {
-    return asText ? thing : <Address address={thing} fontSize={22} />;
+    return asText ? thing : <Address address={thing} fontSize={22} blockExplorer={blockExplorer}/>;
   }
   if (thing && thing.constructor && thing.constructor.name == "Array") {
     const mostReadable = v => (["number", "boolean"].includes(typeof v) ? v : tryToDisplayAsText(v));

--- a/packages/react-app/src/constants.js
+++ b/packages/react-app/src/constants.js
@@ -170,7 +170,7 @@ export const NETWORKS = {
     gasPrice: 225000000000,
   },
   testnetHarmony: {
-    name: "Harmony Testnet",
+    name: "testnetHarmony",
     color: "#00b0ef",
     chainId: 1666700000,
     blockExplorer: "https://explorer.pops.one/",
@@ -178,7 +178,7 @@ export const NETWORKS = {
     gasPrice: 1000000000,
   },
   mainnetHarmony: {
-    name: "Harmony Mainnet",
+    name: "mainnetHarmony",
     color: "#00b0ef",
     chainId: 1666600000,
     blockExplorer: "https://explorer.harmony.one/",


### PR DESCRIPTION
This fixes using the correct block explorer in Contract component (address views).

On the way it also fixes Harmony name in constants to be as the object key (app depends on it to get the RPC correctly).