### PR TITLE
Prevent page from moving when scrollbar appears / disappears

### DIFF
--- a/packages/react-app/src/App.css
+++ b/packages/react-app/src/App.css
@@ -1,3 +1,4 @@
 .App {
   text-align: center;
+  padding-left: calc(100vw - 100%);
 }


### PR DESCRIPTION
For example, when the wallet modal appears the page height is 100% and so there is no scrollbar. But then when the modal disappears the scrollbar comes back and the page shifts. This CSS is a transparent solution to the problem (see https://stackoverflow.com/a/30293718/25068)