### PR TITLE
Add support for Fantom mainnet and testnet

### DIFF
--- a/packages/hardhat/hardhat.config.js
+++ b/packages/hardhat/hardhat.config.js
@@ -152,6 +152,20 @@ module.exports = {
         mnemonic: mnemonic(),
       },
     },
+    fantom: {
+      url: "https://rpcapi.fantom.network",
+      gasPrice: 1000000000,
+      accounts: {
+        mnemonic: mnemonic(),
+      },
+    },
+    testnetFantom: {
+      url: "https://rpc.testnet.fantom.network",
+      gasPrice: 1000000000,
+      accounts: {
+        mnemonic: mnemonic(),
+      },
+    },
     polygon: {
       url: "https://speedy-nodes-nyc.moralis.io/XXXXXXXXXXXXXXXXXXXx/polygon/mainnet", // <---- YOUR MORALIS ID! (not limited to infura)
       gasPrice: 1000000000,
@@ -166,7 +180,6 @@ module.exports = {
         mnemonic: mnemonic(),
       },
     },
-
     matic: {
       url: "https://rpc-mainnet.maticvigil.com/",
       gasPrice: 1000000000,

--- a/packages/react-app/src/constants.js
+++ b/packages/react-app/src/constants.js
@@ -188,7 +188,7 @@ export const NETWORKS = {
   fantom: {
     name: "fantom",
     color: "#1969ff",
-    chainId: 4002,
+    chainId: 250,
     blockExplorer: "https://ftmscan.com/",
     rpcUrl: `https://rpcapi.fantom.network`,
     gasPrice: 1000000000,

--- a/packages/react-app/src/constants.js
+++ b/packages/react-app/src/constants.js
@@ -185,6 +185,23 @@ export const NETWORKS = {
     rpcUrl: `https://api.harmony.one`,
     gasPrice: 1000000000,
   },
+  fantom: {
+    name: "fantom",
+    color: "#1969ff",
+    chainId: 4002,
+    blockExplorer: "https://ftmscan.com/",
+    rpcUrl: `https://rpcapi.fantom.network`,
+    gasPrice: 1000000000,
+  },
+  testnetFantom: {
+    name: "testnetFantom",
+    color: "#1969ff",
+    chainId: 4002,
+    blockExplorer: "https://testnet.ftmscan.com/",
+    rpcUrl: `https://rpc.testnet.fantom.network`,
+    gasPrice: 1000000000,
+    faucet: "https://faucet.fantom.network/",
+  },
 };
 
 export const NETWORK = chainId => {


### PR DESCRIPTION
Since Fantom is entirely EVM compatible it would be nice to include the network in the configuration files of ``hardhat``.

I added Fantom configurations in order to use ``testnet`` or ``mainnet`` for Fantom. 

In order to use this config, just set up inside ``hardhat.config.js`` the defaultNetwork to point out to Fantom

![image](https://user-images.githubusercontent.com/13340320/149989831-93d61322-adbc-4676-9e7c-4e84b16d2053.png)

You can set: **fantom** for ``mainnet`` and **testnetFantom** for ``tests``

It's likely that I would create a tutorial to use this network within **scaffold-eth**

If you don't know Fantom, you can read more here: https://fantom.foundation/