### PR TITLE
Fixed token selector duplicating items

### DIFF
--- a/packages/react-app/src/views/Hints.jsx
+++ b/packages/react-app/src/views/Hints.jsx
@@ -113,7 +113,7 @@ export default function Hints({ yourLocalBalance, mainnetProvider, price, addres
           optionFilterProp="children"
         >
           {listOfTokens.map(token => (
-            <Option key={token.symbol} value={token.symbol}>
+            <Option key={token.address} value={token.symbol}>
               {token.symbol}
             </Option>
           ))}


### PR DESCRIPTION
fixes #632 

The issue was caused by `listOfTokens` containing tokens which have duplicate symbols (CMI, for example). As these symbols were not unique but used as keys for the `Option` components, it caused React to duplicate/overwrite list items while scrolling.