### PR TITLE
Added documentation to specify node version 

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 # 🏄‍♂️ Quick Start
 
-Prerequisites: [Node](https://nodejs.org/en/download/) plus [Yarn](https://classic.yarnpkg.com/en/docs/install/) and [Git](https://git-scm.com/downloads)
+Prerequisites: [Node (v16 LTS)](https://nodejs.org/en/download/) plus [Yarn](https://classic.yarnpkg.com/en/docs/install/) and [Git](https://git-scm.com/downloads)
 
 > clone/fork 🏗 scaffold-eth:
 


### PR DESCRIPTION
- Adds limited documentation to specify the node version to use.
- Experience issue described [here](https://github.com/scaffold-eth/scaffold-eth/discussions/670) when using current version of node.