### PR TITLE
Update Hardhat etherscan to support multiple API keys

### DIFF
--- a/packages/hardhat/hardhat.config.js
+++ b/packages/hardhat/hardhat.config.js
@@ -291,7 +291,10 @@ module.exports = {
     },
   },
   etherscan: {
-    apiKey: "DNXJA8RX2Q3VZ4URQIWP7Z68CJXQZSC6AW",
+    apiKey:{
+        mainnet: "DNXJA8RX2Q3VZ4URQIWP7Z68CJXQZSC6AW",
+        //add other network's API key here
+      }
   },
 };
 

--- a/packages/hardhat/package.json
+++ b/packages/hardhat/package.json
@@ -15,7 +15,7 @@
     "@nomiclabs/hardhat-waffle": "^2.0.0",
     "@openzeppelin/contracts": "^4.4.2",
     "@tenderly/hardhat-tenderly": "^1.0.10",
-    "@nomiclabs/hardhat-etherscan": "^2.1.7",
+    "@nomiclabs/hardhat-etherscan": "^3.0.1",
     "chai": "^4.2.0",
     "chalk": "^4.1.0",
     "dotenv": "^8.2.0",
@@ -41,6 +41,6 @@
     "send": "hardhat send",
     "generate": "hardhat generate",
     "account": "hardhat account",
-    "verify": "hardhat etherscan-verify --api-key PSW8C433Q667DVEX5BCRMGNAH9FSGFZ7Q8"
+    "verify": "hardhat verify"
   }
 }


### PR DESCRIPTION
Bump the version of hardhat-etherscan and change the yarn verify command to use the new format to allow support for multiple API keys for different EVM chains.

See: https://github.com/NomicFoundation/hardhat/issues/1448