### PR TITLE
tokenlist minor bug

### DIFF
--- a/packages/react-app/src/hooks/TokenList.js
+++ b/packages/react-app/src/hooks/TokenList.js
@@ -32,10 +32,10 @@ const useTokenList = (tokenListUri, chainId) => {
               return t.chainId === chainId;
             });
           } else {
-            _tokenList = tokenListJson;
+            _tokenList = tokenListJson.tokens;
           }
 
-          setTokenList(_tokenList.tokens);
+          setTokenList(_tokenList);
         } catch (e) {
           console.log(e);
         }


### PR DESCRIPTION
I noticed whenever a chain id is passed to the useTokenList hook, the returned list is always undefined due to the fact that it's being set to `_tokenList.tokens` after filtering by `chainId`.