### PR TITLE
PunkWallet doesn't work on Polygon

### DIFF
--- a/packages/react-app/package.json
+++ b/packages/react-app/package.json
@@ -21,7 +21,7 @@
     "@ethersproject/bignumber": "^5.0.8",
     "@ethersproject/bytes": "^5.0.5",
     "@ethersproject/contracts": "^5.0.5",
-    "@ethersproject/providers": "^5.0.12",
+    "@ethersproject/providers": "^5.5.6",
     "@ethersproject/solidity": "^5.0.9",
     "@ethersproject/units": "^5.0.6",
     "@ramp-network/ramp-instant-sdk": "^2.2.0",


### PR DESCRIPTION
Hi @austintgriffith ,

I noticed that I cannot transfer funds with PunkWallet on the Polygon chain.
After debugging the code it turned out to be an ethers bug, which is now fixed in the latest version - 5.5.6.

Here is the ethers issue:
https://github.com/ethers-io/ethers.js/issues/2691

**Note:**
Actually PunkWallet still doesn't work on Polygon, because the gasPrice is set to 1gwei, which is not enough right now.
I can look into this later, manually setting the gasPrice worked for me, my transaction was confirmed.

Best,
Tamas