### PR TITLE
Updated IPFS script to use newer API from 'ipfs-http-client'

### DIFF
--- a/packages/react-app/scripts/ipfs.js
+++ b/packages/react-app/scripts/ipfs.js
@@ -25,7 +25,6 @@ const pushDirectoryToIPFS = async path => {
     }
     return lastRes
   } catch (e) {
-    console.log(e)
     return {};
   }
 };
@@ -33,7 +32,6 @@ const pushDirectoryToIPFS = async path => {
 const publishHashToIPNS = async ipfsHash => {
   try {
     const response = await ipfs.name.publish(`/ipfs/${ipfsHash}`);
-    console.log(response)
     return response;
   } catch (e) {
     return {};

--- a/packages/react-app/scripts/ipfs.js
+++ b/packages/react-app/scripts/ipfs.js
@@ -1,27 +1,31 @@
-const ipfsAPI = require("ipfs-http-client");
+const {create, globSource} = require("ipfs-http-client");
 const chalk = require("chalk");
 const { clearLine } = require("readline");
-
-const { globSource } = ipfsAPI;
 
 const infura = { host: "ipfs.infura.io", port: "5001", protocol: "https" };
 // run your own ipfs daemon: https://docs.ipfs.io/how-to/command-line-quick-start/#install-ipfs
 // const localhost = { host: "localhost", port: "5001", protocol: "http" };
 
-const ipfs = ipfsAPI(infura);
+const ipfs =  create(infura);
 
 const ipfsGateway = "https://ipfs.io/ipfs/";
 const ipnsGateway = "https://ipfs.io/ipns/";
 
 const addOptions = {
   pin: true,
+  wrapWithDirectory: true
 };
 
 const pushDirectoryToIPFS = async path => {
   try {
-    const response = await ipfs.add(globSource(path, { recursive: true }), addOptions);
-    return response;
+    const file = ipfs.addAll(globSource(path, '**/*'), addOptions)
+    let lastRes;
+    for await (const f of file) {
+      lastRes = f
+    }
+    return lastRes
   } catch (e) {
+    console.log(e)
     return {};
   }
 };
@@ -29,6 +33,7 @@ const pushDirectoryToIPFS = async path => {
 const publishHashToIPNS = async ipfsHash => {
   try {
     const response = await ipfs.name.publish(`/ipfs/${ipfsHash}`);
+    console.log(response)
     return response;
   } catch (e) {
     return {};


### PR DESCRIPTION
The ipfs script uses an different API from an older version of the package `ipfs-http-client`. I have updated the script to work with `ipfs-http-client@55.0.0` which is the version that is installed when running `yarn install`.

Currently, running `yarn run ipfs` on the master branch is broken.

<img width="751" alt="image" src="https://user-images.githubusercontent.com/87622099/159122376-452ee692-7e34-4a6d-9af6-05b564c9077f.png">

I have updated the ipfs script to match the new API in the library ipfs-http-client@55.0.0 in this pr.




