### PR TITLE
Adds Moonbeam network information

### DIFF
--- a/packages/hardhat/hardhat.config.js
+++ b/packages/hardhat/hardhat.config.js
@@ -229,6 +229,34 @@ module.exports = {
         mnemonic: mnemonic(),
       },
     },
+    moonbeam: {
+      url: 'https://rpc.api.moonbeam.network',
+      chainId: 1284,
+      accounts: {
+        mnemonic: mnemonic(),
+      },
+    },
+    moonriver: {
+      url: 'https://rpc.api.moonriver.moonbeam.network',
+      chainId: 1285,
+      accounts: {
+        mnemonic: mnemonic(),
+      },
+    },
+    moonbaseAlpha: {
+      url: 'https://rpc.api.moonbase.moonbeam.network',
+      chainId: 1287,
+      accounts: {
+        mnemonic: mnemonic(),
+      },
+    },
+    moonbeamDevNode: {
+      url: 'http://127.0.0.1:9933',
+      chainId: 1281,
+      accounts: {
+        mnemonic: mnemonic(),
+      },
+    }
   },
   solidity: {
     compilers: [

--- a/packages/react-app/src/constants.js
+++ b/packages/react-app/src/constants.js
@@ -172,6 +172,35 @@ export const NETWORKS = {
     gasPrice: 1000000000,
     faucet: "https://faucet.fantom.network/",
   },
+  moonbeam: {
+    name: "moonbeam",
+    color: "#53CBC9",
+    chainId: 1284,
+    blockExplorer: "https://moonscan.io",
+    rpcUrl: "https://rpc.api.moonbeam.network", 
+  },
+  moonriver: {
+    name: "moonriver",
+    color: "#53CBC9",
+    chainId: 1285,
+    blockExplorer: "https://moonriver.moonscan.io/",
+    rpcUrl: "https://rpc.api.moonriver.moonbeam.network",
+  },
+  moonbaseAlpha: {
+    name: "moonbaseAlpha",
+    color: "#53CBC9",
+    chainId: 1287,
+    blockExplorer: "https://moonbase.moonscan.io/",
+    rpcUrl: "https://rpc.api.moonbase.moonbeam.network",
+    faucet: "https://discord.gg/SZNP8bWHZq",
+  },
+  moonbeamDevNode: {
+    name: "moonbeamDevNode",
+    color: "#53CBC9",
+    chainId: 1281,
+    blockExplorer: "https://moonbeam-explorer.netlify.app/",
+    rpcUrl: "http://127.0.0.1:9933",
+  }
 };
 
 export const NETWORK = chainId => {


### PR DESCRIPTION
Adds Moonbeam networks and related information such as chain ID and RPC endpoints to the Hardhat and React config files. 

The project [works well with Moonbeam](https://docs.moonbeam.network/builders/build/eth-api/dev-env/scaffold-eth/), and would be good to have the networks listed in the configuration files. 
