### PR TITLE
Remove walletConnectUrl from localStorage in case the connection wasn't successful.

### DIFF
--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -232,7 +232,15 @@ function App(props) {
   const connectWallet = (sessionDetails)=>{
     console.log(" 📡 Connecting to Wallet Connect....",sessionDetails)
 
-    const connector = new WalletConnect(sessionDetails);
+    let connector;
+    try {
+      connector = new WalletConnect(sessionDetails);
+    }
+    catch(error) {
+      console.error("Coudn't connect to", sessionDetails, error);
+      localStorage.removeItem("walletConnectUrl");
+      return;
+    }
 
     setWallectConnectConnector(connector)
 


### PR DESCRIPTION
Copy-pasting a wrong link accidentally, or simply typing something in the "wallect connect url" input breaks the app.
It won't load at all until we remove "walletConnectUrl" from localStorage.