### PR TITLE
Add hardhat-abi-exporter plugin

### DIFF
--- a/packages/hardhat/hardhat.config.js
+++ b/packages/hardhat/hardhat.config.js
@@ -8,6 +8,7 @@ require("@tenderly/hardhat-tenderly");
 
 require("hardhat-deploy");
 require("hardhat-gas-reporter");
+require("hardhat-abi-exporter");
 
 require("@nomiclabs/hardhat-ethers");
 require("@nomiclabs/hardhat-etherscan");
@@ -265,6 +266,15 @@ module.exports = {
       mainnet: "DNXJA8RX2Q3VZ4URQIWP7Z68CJXQZSC6AW",
       // add other network's API key here
     },
+  },
+  abiExporter: {
+    path: "../react-app/src/contracts",
+    runOnCompile: true,
+    clear: true,
+    flat: true,
+    only: [],
+    spacing: 2,
+    pretty: false,
   },
 };
 

--- a/packages/hardhat/package.json
+++ b/packages/hardhat/package.json
@@ -24,6 +24,7 @@
     "hardhat": "2.6.0",
     "hardhat-deploy": "^0.9.0",
     "hardhat-gas-reporter": "^1.0.4",
+    "hardhat-abi-exporter": "^2.8.0",
     "node-watch": "^0.7.0",
     "qrcode-terminal": "^0.12.0",
     "ramda": "^0.27.1"


### PR DESCRIPTION
Added hardhat-abi-exporter to dependency list of hardhat. This helps when there are multiple contracts and one contract is uses as state inside another. At deploy time we can only export deployed contracts abi but sometimes need arises where you want to call function of contract that is used as state inside deployed contract. 

This plugin exports abi of all the contracts inside "../react-app/src/contracts" with same name as contracts inside a json file for each contract. You can just export abi and create the Read/WriteContract using the address of state contacts and abi.

Usecase:
MultiISigWallet uses as state inside MultiSigFactory and MultiSigFactory gets deployed and you dynamically create MultiISigWallet and want to call function of MultiISigWallet