### PR TITLE
Export ABI to a sub directory instead of contracts directory

### DIFF
--- a/packages/hardhat/hardhat.config.js
+++ b/packages/hardhat/hardhat.config.js
@@ -296,7 +296,7 @@ module.exports = {
     },
   },
   abiExporter: {
-    path: "../react-app/src/contracts",
+    path: "../react-app/src/contracts/ABI",
     runOnCompile: true,
     clear: true,
     flat: true,


### PR DESCRIPTION
Make contracts directory cleaner by separating exported ABI from deployed contracts


<img width="379" alt="Screen Shot 2022-04-25 at 7 35 07 AM" src="https://user-images.githubusercontent.com/14002941/165033268-9ee753fb-0008-49be-9cdd-8a1badfece51.png">

