### PR TITLE
fix prettier warnings

### DIFF
--- a/packages/react-app/src/components/Header.jsx
+++ b/packages/react-app/src/components/Header.jsx
@@ -3,21 +3,16 @@ import React from "react";
 
 // displays a page header
 
-export default function Header({link, title, subTitle}) {
+export default function Header({ link, title, subTitle }) {
   return (
     <a href={link} target="_blank" rel="noopener noreferrer">
-      <PageHeader
-        title={title}
-        subTitle={subTitle}
-        style={{ cursor: "pointer" }}
-      />
+      <PageHeader title={title} subTitle={subTitle} style={{ cursor: "pointer" }} />
     </a>
   );
 }
-
 
 Header.defaultProps = {
   link: "https://github.com/austintgriffith/scaffold-eth",
   title: "🏗 scaffold-eth",
   subTitle: "forkable Ethereum dev stack focused on fast product iteration",
-}
+};

--- a/packages/react-app/src/constants.js
+++ b/packages/react-app/src/constants.js
@@ -177,7 +177,7 @@ export const NETWORKS = {
     color: "#53CBC9",
     chainId: 1284,
     blockExplorer: "https://moonscan.io",
-    rpcUrl: "https://rpc.api.moonbeam.network", 
+    rpcUrl: "https://rpc.api.moonbeam.network",
   },
   moonriver: {
     name: "moonriver",
@@ -200,7 +200,7 @@ export const NETWORKS = {
     chainId: 1281,
     blockExplorer: "https://moonbeam-explorer.netlify.app/",
     rpcUrl: "http://127.0.0.1:9933",
-  }
+  },
 };
 
 export const NETWORK = chainId => {


### PR DESCRIPTION
fix prettier warnings 

```Compiled with warnings.

src/components/Header.jsx
  Line 6:33:  Replace `link,·title,·subTitle` with `·link,·title,·subTitle·`                                                                                                                    prettier/prettier
  Line 9:18:  Replace `⏎········title={title}⏎········subTitle={subTitle}⏎········style={{·cursor:·"pointer"·}}⏎·····` with `·title={title}·subTitle={subTitle}·style={{·cursor:·"pointer"·}}`  prettier/prettier
  Line 16:2:  Delete `⏎`                                                                                                                                                                        prettier/prettier
  Line 23:2:  Insert `;⏎`                                                                                                                                                                       prettier/prettier

src/constants.js
  Line 180:48:  Delete `·`  prettier/prettier
  Line 203:4:   Insert `,`  prettier/prettier

Search for the keywords to learn more about each warning.
To ignore, add // eslint-disable-next-line to the line before.`