### PR TITLE
Improving header and account responsiveness

### DIFF
--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -247,7 +247,37 @@ function App(props) {
   return (
     <div className="App">
       {/* ✏️ Edit the header and change the title to your project name */}
-      <Header />
+      <Header>
+        {/* 👨‍💼 Your account is in the top right with a wallet at connect options */}
+        <div style={{ position: "relative", display: "flex", flexDirection: "column" }}>
+          <div style={{ display: "flex", flex: 1 }}>
+            {USE_NETWORK_SELECTOR && (
+              <div style={{ marginRight: 20 }}>
+                <NetworkSwitch
+                  networkOptions={networkOptions}
+                  selectedNetwork={selectedNetwork}
+                  setSelectedNetwork={setSelectedNetwork}
+                />
+              </div>
+            )}
+            <Account
+              useBurner={USE_BURNER_WALLET}
+              address={address}
+              localProvider={localProvider}
+              userSigner={userSigner}
+              mainnetProvider={mainnetProvider}
+              price={price}
+              web3Modal={web3Modal}
+              loadWeb3Modal={loadWeb3Modal}
+              logoutOfWeb3Modal={logoutOfWeb3Modal}
+              blockExplorer={blockExplorer}
+            />
+          </div>
+        </div>
+      </Header>
+      {yourLocalBalance.lte(ethers.BigNumber.from("0")) && (
+        <FaucetHint localProvider={localProvider} targetNetwork={targetNetwork} address={address} />
+      )}
       <NetworkDisplay
         NETWORKCHECK={NETWORKCHECK}
         localChainId={localChainId}
@@ -354,36 +384,6 @@ function App(props) {
       </Switch>
 
       <ThemeSwitch />
-
-      {/* 👨‍💼 Your account is in the top right with a wallet at connect options */}
-      <div style={{ position: "fixed", textAlign: "right", right: 0, top: 0, padding: 10 }}>
-        <div style={{ display: "flex", flex: 1, alignItems: "center" }}>
-          {USE_NETWORK_SELECTOR && (
-            <div style={{ marginRight: 20 }}>
-              <NetworkSwitch
-                networkOptions={networkOptions}
-                selectedNetwork={selectedNetwork}
-                setSelectedNetwork={setSelectedNetwork}
-              />
-            </div>
-          )}
-          <Account
-            useBurner={USE_BURNER_WALLET}
-            address={address}
-            localProvider={localProvider}
-            userSigner={userSigner}
-            mainnetProvider={mainnetProvider}
-            price={price}
-            web3Modal={web3Modal}
-            loadWeb3Modal={loadWeb3Modal}
-            logoutOfWeb3Modal={logoutOfWeb3Modal}
-            blockExplorer={blockExplorer}
-          />
-        </div>
-        {yourLocalBalance.lte(ethers.BigNumber.from("0")) && (
-          <FaucetHint localProvider={localProvider} targetNetwork={targetNetwork} address={address} />
-        )}
-      </div>
 
       {/* 🗺 Extra UI like gas price, eth price, faucet, and support: */}
       <div style={{ position: "fixed", textAlign: "left", left: 0, bottom: 20, padding: 10 }}>

--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -286,7 +286,7 @@ function App(props) {
         logoutOfWeb3Modal={logoutOfWeb3Modal}
         USE_NETWORK_SELECTOR={USE_NETWORK_SELECTOR}
       />
-      <Menu style={{ textAlign: "center", marginTop: 40 }} selectedKeys={[location.pathname]} mode="horizontal">
+      <Menu style={{ textAlign: "center", marginTop: 20 }} selectedKeys={[location.pathname]} mode="horizontal">
         <Menu.Item key="/">
           <Link to="/">App Home</Link>
         </Menu.Item>

--- a/packages/react-app/src/components/Account.jsx
+++ b/packages/react-app/src/components/Account.jsx
@@ -15,7 +15,6 @@ import Wallet from "./Wallet";
   ~ How can I use? ~
 
   <Account
-    useBurner={boolean}
     address={address}
     localProvider={localProvider}
     userProvider={userProvider}
@@ -43,7 +42,6 @@ import Wallet from "./Wallet";
 **/
 
 export default function Account({
-  useBurner,
   address,
   userSigner,
   localProvider,
@@ -58,85 +56,51 @@ export default function Account({
 }) {
   const { currentTheme } = useThemeSwitcher();
 
-  const modalButtons = [];
-  if (web3Modal) {
-    if (web3Modal.cachedProvider) {
-      modalButtons.push(
-        <Button
-          key="logoutbutton"
-          style={{ verticalAlign: "top", marginLeft: 8, marginTop: 4 }}
-          shape="round"
-          size="large"
-          onClick={logoutOfWeb3Modal}
-        >
-          logout
-        </Button>,
-      );
-    } else {
-      modalButtons.push(
-        <Button
-          key="loginbutton"
-          style={{ verticalAlign: "top", marginLeft: 8, marginTop: 4 }}
-          shape="round"
-          size="large"
-          /* type={minimized ? "default" : "primary"}     too many people just defaulting to MM and having a bad time */
-          onClick={loadWeb3Modal}
-        >
-          connect
-        </Button>,
-      );
-    }
+  let accountButtonInfo;
+  if (web3Modal?.cachedProvider) {
+    accountButtonInfo = { name: 'Logout', action: logoutOfWeb3Modal };
+  } else {
+    accountButtonInfo = { name: 'Connect', action: loadWeb3Modal };
   }
-  const display = minimized ? (
-    ""
-  ) : (
+
+  const display = !minimized && (
     <span>
-      {web3Modal && web3Modal.cachedProvider ? (
-        <>
-          {address && <Address address={address} ensProvider={mainnetProvider} blockExplorer={blockExplorer} />}
-          <Balance address={address} provider={localProvider} price={price} />
-          <Wallet
-            address={address}
-            provider={localProvider}
-            signer={userSigner}
-            ensProvider={mainnetProvider}
-            price={price}
-            color={currentTheme === "light" ? "#1890ff" : "#2caad9"}
-          />
-        </>
-      ) : useBurner ? (
-        ""
-      ) : isContract ? (
-        <>
-          {address && <Address address={address} ensProvider={mainnetProvider} blockExplorer={blockExplorer} />}
-          <Balance address={address} provider={localProvider} price={price} />
-        </>
-      ) : (
-        ""
+      {address && (
+        <Address
+          address={address}
+          ensProvider={mainnetProvider}
+          blockExplorer={blockExplorer}
+          fontSize={20}
+        />
       )}
-      {useBurner && web3Modal && !web3Modal.cachedProvider ? (
-        <>
-          <Address address={address} ensProvider={mainnetProvider} blockExplorer={blockExplorer} />
-          <Balance address={address} provider={localProvider} price={price} />
-          <Wallet
-            address={address}
-            provider={localProvider}
-            signer={userSigner}
-            ensProvider={mainnetProvider}
-            price={price}
-            color={currentTheme === "light" ? "#1890ff" : "#2caad9"}
-          />
-        </>
-      ) : (
-        <></>
+      <Balance address={address} provider={localProvider} price={price} size={20} />
+      {!isContract && (
+        <Wallet
+          address={address}
+          provider={localProvider}
+          signer={userSigner}
+          ensProvider={mainnetProvider}
+          price={price}
+          color={currentTheme === "light" ? "#1890ff" : "#2caad9"}
+          size={22}
+          padding={"0px"}
+        />
       )}
     </span>
   );
 
   return (
-    <div>
+    <div style={{ display: "flex" }}>
       {display}
-      {modalButtons}
+      {web3Modal && (
+        <Button
+          style={{ marginLeft: 8 }}
+          shape="round"
+          onClick={accountButtonInfo.action}
+        >
+          {accountButtonInfo.name}
+        </Button>
+      )}
     </div>
   );
 }

--- a/packages/react-app/src/components/FaucetHint.jsx
+++ b/packages/react-app/src/components/FaucetHint.jsx
@@ -28,7 +28,7 @@ function FaucetHint({ localProvider, targetNetwork, address }) {
     ethers.utils.formatEther(yourLocalBalance) <= 0
   ) {
     faucetHint = (
-      <div style={{ padding: 16, display: "inline-flex" }}>
+      <div style={{ position: "absolute", right: 65, top: 65 }}>
         <Button
           type="primary"
           onClick={() => {

--- a/packages/react-app/src/components/Header.jsx
+++ b/packages/react-app/src/components/Header.jsx
@@ -1,13 +1,21 @@
-import { PageHeader } from "antd";
 import React from "react";
+import { Typography } from "antd";
+
+const { Title, Text } = Typography;
 
 // displays a page header
 
-export default function Header({ link, title, subTitle }) {
+export default function Header({ link, title, subTitle, ...props }) {
   return (
-    <a href={link} target="_blank" rel="noopener noreferrer">
-      <PageHeader title={title} subTitle={subTitle} style={{ cursor: "pointer" }} />
-    </a>
+    <div style={{ display: "flex", justifyContent: "space-between", padding: "1.2rem" }}>
+      <div style={{ display: "flex",  flexDirection: "column", flex: 1, alignItems: "start" }}>
+        <a href={link} target="_blank" rel="noopener noreferrer">
+          <Title level={4} style={{ margin: "0 0.5rem 0 0" }}>{title}</Title>
+        </a>
+        <Text type="secondary" style={{ textAlign: "left" }}>{subTitle}</Text>
+      </div>
+      {props.children}
+    </div>
   );
 }
 

--- a/packages/react-app/src/components/NetworkDisplay.jsx
+++ b/packages/react-app/src/components/NetworkDisplay.jsx
@@ -90,7 +90,7 @@ function NetworkDisplay({
     }
   } else {
     networkDisplay = USE_NETWORK_SELECTOR ? null : (
-      <div style={{ zIndex: -1, position: "absolute", right: 154, top: 28, padding: 16, color: targetNetwork.color }}>
+      <div style={{ zIndex: -1, position: "absolute", right: 150, top: 25, padding: 16, color: targetNetwork.color }}>
         {targetNetwork.name}
       </div>
     );

--- a/packages/react-app/src/components/Wallet.jsx
+++ b/packages/react-app/src/components/Wallet.jsx
@@ -68,10 +68,10 @@ export default function Wallet(props) {
         }}
         rotate={-90}
         style={{
-          padding: 7,
+          padding: props.padding ? props.padding : 7,
           color: props.color ? props.color : "",
           cursor: "pointer",
-          fontSize: 28,
+          fontSize: props.size ? props.size : 28,
           verticalAlign: "middle",
         }}
       />


### PR DESCRIPTION
### What does this solving?

Currently the balance and address (in the `Account` component) overlap with the logo on smaller screens.

This PR introduces style and component changes that improve the header responsiveness as well as the general UI of the account component such as:
- smaller address and balance font size
- removing the fixed positioning of the account component in favour of using flex box styles in the `Header` component
- placing the long subtitle string under the main logo

**Desktop:**
<img width="1053" alt="image" src="https://user-images.githubusercontent.com/12888080/167340293-d33cf6cb-d9b4-4b72-8638-0b5de3576c91.png">

**Phone screen:**
<img width="735" alt="image" src="https://user-images.githubusercontent.com/12888080/167340362-866968e4-625d-4cb1-82b8-84310f46ebe9.png">

**Cluttered header with network selector also work most of the time:**
<img width="445" alt="image" src="https://user-images.githubusercontent.com/12888080/167340645-912dd70b-b440-45ac-bde1-100f2013e549.png">
