### PR TITLE
Fix private key display issue. Instead of displaying the private key …in the URL / when hovering the mouse on the account, use the local storage key only.

### DIFF
--- a/packages/react-app/src/components/Wallet.jsx
+++ b/packages/react-app/src/components/Wallet.jsx
@@ -186,7 +186,7 @@ export default function Wallet(props) {
             }}
           />
         </div>
-        <a href={"/pk#" + pk}>
+        <a href={"/pk#" + "metaPrivateKey"}>
           <Blockie address={wallet.address} scale={4} /> {wallet.address.substr(0, 6)}
         </a>
       </div>,
@@ -208,7 +208,7 @@ export default function Wallet(props) {
           const y = parseInt(part2, 16) % 100;
           extraPkDisplay.push(
             <div style={{ fontSize: 32 }}>
-              <a href={"/pk#" + pastpk}>
+              <a href={"/pk#" + key}>
                 <div
                   style={{ float: "left", position: "relative", width: punkSize, height: punkSize, overflow: "hidden" }}
                 >

--- a/packages/react-app/src/hooks/UserProvider.js
+++ b/packages/react-app/src/hooks/UserProvider.js
@@ -33,7 +33,9 @@ const useUserProvider = (injectedProvider, localProvider) =>
 
     if (window.location.pathname) {
       if (window.location.pathname.indexOf("/pk") >= 0) {
-        const incomingPK = window.location.hash.replace("#", "");
+        const incomingLocalStorageKeyt = window.location.hash.replace("#", "");
+        const incomingPK = localStorage.getItem(incomingLocalStorageKeyt);
+
         let rawPK;
         if (incomingPK.length === 64 || incomingPK.length === 66) {
           console.log("🔑 Incoming Private Key...");

--- a/packages/react-app/src/hooks/UserProvider.js
+++ b/packages/react-app/src/hooks/UserProvider.js
@@ -33,8 +33,11 @@ const useUserProvider = (injectedProvider, localProvider) =>
 
     if (window.location.pathname) {
       if (window.location.pathname.indexOf("/pk") >= 0) {
-        const incomingLocalStorageKeyt = window.location.hash.replace("#", "");
-        const incomingPK = localStorage.getItem(incomingLocalStorageKeyt);
+        let incomingPK = window.location.hash.replace("#", "");
+
+        if (incomingPK.startsWith("metaPrivateKey")) {
+          incomingPK = localStorage.getItem(incomingPK);
+        }
 
         let rawPK;
         if (incomingPK.length === 64 || incomingPK.length === 66) {


### PR DESCRIPTION
Hey @austintgriffith 

We talked about this issue before, currently punkwallet displays the private key in the url when we're switching accounts.

I replaced the private key with the local storage key.


![image](https://user-images.githubusercontent.com/1397179/168672267-a6d0e7e2-0b04-43d1-97f5-675f38fe8a0b.png)
