### PR TITLE
Punk wallet wallet connect update

### DIFF
--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -436,6 +436,21 @@ function App(props) {
   //store the connector session in local storage so sessions persist through page loads ( thanks Pedro <3 )
   const [ wallectConnectConnectorSession, setWallectConnectConnectorSession ] = useLocalStorage("wallectConnectConnectorSession")
 
+  if (wallectConnectConnector && wallectConnectConnector.connected && address) {
+    const connectedAddress = wallectConnectConnector.accounts[0];
+
+    // Use Checksummed addresses
+    if (ethers.utils.getAddress(connectedAddress) != ethers.utils.getAddress(address)) {
+      console.log("Updating wallet connect session with the new address");
+      console.log("Connected address", ethers.utils.getAddress(connectedAddress));
+      console.log("New address ", ethers.utils.getAddress(address));
+
+      wallectConnectConnector.updateSession({
+        accounts: [address],
+      });
+    }
+  }
+
   useEffect(()=>{
     if(!walletConnectConnected && address){
       let nextSession = localStorage.getItem("wallectConnectNextSession")

--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -2,7 +2,7 @@ import { CaretUpOutlined, ScanOutlined, SendOutlined, ReloadOutlined } from "@an
 import { JsonRpcProvider, StaticJsonRpcProvider, Web3Provider } from "@ethersproject/providers";
 import { formatEther, parseEther } from "@ethersproject/units";
 import WalletConnectProvider from "@walletconnect/web3-provider";
-import { Alert, Button, Col, Row, Select, Input, Modal, notification } from "antd";
+import { Alert, Button, Col, Row, Select, Spin, Input, Modal, notification } from "antd";
 import "antd/dist/antd.css";
 import { useUserAddress } from "eth-hooks";
 import React, { useCallback, useEffect, useState, useMemo } from "react";
@@ -1139,6 +1139,14 @@ function App(props) {
       </div>
 
       <div style={{ clear: "both", width: 500, margin: "auto" ,marginTop:32, position:"relative"}}>
+        {(wallectConnectConnector && !wallectConnectConnector.connected) && 
+
+          <div>
+            <Spin />
+            <div>
+               Connecting to the Dapp...
+            </div>   
+          </div>}
         {walletConnectConnected ?
           <>
             {(walletConnectPeerMeta?.icons[0]) ? 

--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -417,6 +417,9 @@ function App(props) {
       }
       console.log("disconnect")
 
+      localStorage.removeItem("walletConnectUrl")
+      localStorage.removeItem("wallectConnectConnectorSession")
+
       setTimeout(() => {
         window.location.reload();
       }, 1);

--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -235,6 +235,10 @@ function App(props) {
     let connector;
     try {
       connector = new WalletConnect(sessionDetails);
+      const { peerMeta } = connector;
+      if (peerMeta) {
+        setWalletConnectPeerMeta(peerMeta);
+      }
     }
     catch(error) {
       console.error("Coudn't connect to", sessionDetails, error);
@@ -262,6 +266,10 @@ function App(props) {
 
       setWalletConnectConnected(true)
       setWallectConnectConnectorSession(connector.session)
+      const { peerMeta } = payload.params[0];
+      if (peerMeta) {
+        setWalletConnectPeerMeta(peerMeta);
+      }
 
       /* payload:
       {
@@ -419,6 +427,7 @@ function App(props) {
 
   const [ walletConnectUrl, setWalletConnectUrl ] = useLocalStorage("walletConnectUrl")
   const [ walletConnectConnected, setWalletConnectConnected ] = useState()
+  const [ walletConnectPeerMeta, setWalletConnectPeerMeta ] = useState()
 
   const [ wallectConnectConnector, setWallectConnectConnector ] = useState()
   //store the connector session in local storage so sessions persist through page loads ( thanks Pedro <3 )
@@ -1087,7 +1096,18 @@ function App(props) {
       </div>
 
       <div style={{ clear: "both", width: 500, margin: "auto" ,marginTop:32, position:"relative"}}>
-        {walletConnectConnected?<span style={{cursor:"pointer",padding:8,fontSize:30,position:"absolute",top:-16,left:28}}>✅</span>:""}
+        {walletConnectConnected ?
+          <>
+            {(walletConnectPeerMeta?.icons[0]) ? 
+              <span >
+              {walletConnectPeerMeta?.icons[0] && <img style={{width: 40, top:-4, position:"absolute",left:26}} src={walletConnectPeerMeta.icons[0]} alt={walletConnectPeerMeta.name ? walletConnectPeerMeta.name : ""} />}
+              </span>
+              :
+              <span style={{cursor:"pointer",padding:8,fontSize:30,position:"absolute",top:-16,left:28}}>✅</span>
+            }
+          </>
+          :""
+        }
         <Input
           style={{width:"70%"}}
           placeholder={"wallet connect url (or use the scanner-->)"}

--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -260,7 +260,7 @@ function App(props) {
         chainId: targetNetwork.chainId               // required
       })
 
-      setConnected(true)
+      setWalletConnectConnected(true)
       setWallectConnectConnectorSession(connector.session)
 
       /* payload:
@@ -418,14 +418,14 @@ function App(props) {
   }
 
   const [ walletConnectUrl, setWalletConnectUrl ] = useLocalStorage("walletConnectUrl")
-  const [ connected, setConnected ] = useState()
+  const [ walletConnectConnected, setWalletConnectConnected ] = useState()
 
   const [ wallectConnectConnector, setWallectConnectConnector ] = useState()
   //store the connector session in local storage so sessions persist through page loads ( thanks Pedro <3 )
   const [ wallectConnectConnectorSession, setWallectConnectConnectorSession ] = useLocalStorage("wallectConnectConnectorSession")
 
   useEffect(()=>{
-    if(!connected){
+    if(!walletConnectConnected){
       let nextSession = localStorage.getItem("wallectConnectNextSession")
       if(nextSession){
         localStorage.removeItem("wallectConnectNextSession")
@@ -434,7 +434,7 @@ function App(props) {
       }else if(wallectConnectConnectorSession){
         console.log("NOT CONNECTED AND wallectConnectConnectorSession",wallectConnectConnectorSession)
         connectWallet( wallectConnectConnectorSession )
-        setConnected(true)
+        setWalletConnectConnected(true)
       }else if(walletConnectUrl/*&&!walletConnectUrlSaved*/){
         //CLEAR LOCAL STORAGE?!?
         console.log("clear local storage and connect...")
@@ -837,11 +837,11 @@ function App(props) {
             walletConnect={(wcLink)=>{
               //if(walletConnectUrl){
                 /*try{
-                  //setConnected(false);
+                  //setWalletConnectConnected(false);
                   //setWalletConnectUrl();
                   //if(wallectConnectConnector) wallectConnectConnector.killSession();
                   //if(wallectConnectConnectorSession) setWallectConnectConnectorSession("");
-                  setConnected(false);
+                  setWalletConnectConnected(false);
                   //if(wallectConnectConnector) wallectConnectConnector.killSession();
                   localStorage.removeItem("walletConnectUrl")
                   localStorage.removeItem("wallectConnectConnectorSession")
@@ -854,7 +854,7 @@ function App(props) {
 
               if(walletConnectUrl){
                 //existing session... need to kill it and then connect new one....
-                setConnected(false);
+                setWalletConnectConnected(false);
                 if(wallectConnectConnector) wallectConnectConnector.killSession();
                 localStorage.removeItem("walletConnectUrl")
                 localStorage.removeItem("wallectConnectConnectorSession")
@@ -1087,17 +1087,17 @@ function App(props) {
       </div>
 
       <div style={{ clear: "both", width: 500, margin: "auto" ,marginTop:32, position:"relative"}}>
-        {connected?<span style={{cursor:"pointer",padding:8,fontSize:30,position:"absolute",top:-16,left:28}}>✅</span>:""}
+        {walletConnectConnected?<span style={{cursor:"pointer",padding:8,fontSize:30,position:"absolute",top:-16,left:28}}>✅</span>:""}
         <Input
           style={{width:"70%"}}
           placeholder={"wallet connect url (or use the scanner-->)"}
           value={walletConnectUrl}
-          disabled={connected}
+          disabled={walletConnectConnected}
           onChange={(e)=>{
             setWalletConnectUrl(e.target.value)
           }}
-        />{connected?<span style={{cursor:"pointer",padding:10,fontSize:30,position:"absolute", top:-18}} onClick={()=>{
-          setConnected(false);
+        />{walletConnectConnected?<span style={{cursor:"pointer",padding:10,fontSize:30,position:"absolute", top:-18}} onClick={()=>{
+          setWalletConnectConnected(false);
           if(wallectConnectConnector) wallectConnectConnector.killSession();
           localStorage.removeItem("walletConnectUrl")
           localStorage.removeItem("wallectConnectConnectorSession")

--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -437,7 +437,7 @@ function App(props) {
   const [ wallectConnectConnectorSession, setWallectConnectConnectorSession ] = useLocalStorage("wallectConnectConnectorSession")
 
   useEffect(()=>{
-    if(!walletConnectConnected){
+    if(!walletConnectConnected && address){
       let nextSession = localStorage.getItem("wallectConnectNextSession")
       if(nextSession){
         localStorage.removeItem("wallectConnectNextSession")
@@ -472,7 +472,7 @@ function App(props) {
               }*/)
       }
     }
-  },[ walletConnectUrl ])
+  },[ walletConnectUrl, address ])
 
   useMemo(() => {
     if (address && window.location.pathname) {


### PR DESCRIPTION
Hey guys,

This PR is about Wallet Connect, it should do the following:

1. Display the Dapp's icon instead of the green checkmark
2. Cleans up Wallet Connect from localStorage, when the Dapp has disconnected (previously the green checkmark was still visible)
3. We should be able to connect to another Dapp, without deleting the old session manually (just shoot the new Dapp's QR code)
4. Update the Dapp with the new adress/chainId we selected (ENS handles the new chain quite weirdly)
5. Display a spinner when we're waiting for the connection (sometimes it took 5-10 seconds for me, other times it's very fast)

<img width="738" alt="image" src="https://user-images.githubusercontent.com/1397179/174334521-5f07782b-9d56-4440-b99c-e439294135e6.png">

<img width="565" alt="image" src="https://user-images.githubusercontent.com/1397179/174334659-fe9eccb9-7eff-426d-827b-8497e7ebdfe7.png">

<img width="541" alt="image" src="https://user-images.githubusercontent.com/1397179/174334816-9012374f-a996-476e-a583-f570ee80619e.png">
