### PR TITLE
feat: add optional scaffold-eth-cli command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ Prerequisites: [Node (v16 LTS)](https://nodejs.org/en/download/) plus [Yarn (v1.
 git clone https://github.com/scaffold-eth/scaffold-eth.git
 ```
 
+or using `scaffold-eth-cli`:
+
+```bash
+npx scaffold-eth
+```
+
 > install and start your 👷‍ Hardhat chain:
 
 ```bash


### PR DESCRIPTION
This PR is intended as a temperature test for:
* providing traction to `scaffold-eth-cli` to further determine,
* if using `scaffold-eth-cli` is helpful for repeat iterators
  * think instead of having to find the right thing to clone everytime, you could simply do: `npx scaffold-eth nextjs-typescript` or `npx scaffold-eth <branch-name>`, maybe with some fuzzy searching algo
* if `scaffold-eth-cli` can be absorbed into the `scaffold-eth` org as a product to take forward 

cc @codenamejason @austintgriffith 