### PR TITLE
fix(react-app): update old subgraph docs link

### DIFF
--- a/packages/react-app/src/views/Subgraph.jsx
+++ b/packages/react-app/src/views/Subgraph.jsx
@@ -147,7 +147,7 @@ function Subgraph(props) {
           packages/subgraph/src
         </span>
         (learn more about subgraph definition{" "}
-        <a href="https://thegraph.com/docs/define-a-subgraph" target="_blank" rel="noopener noreferrer">
+        <a href="https://thegraph.com/docs/en/developer/define-subgraph-hosted/" target="_blank" rel="noopener noreferrer">
           here
         </a>
         )


### PR DESCRIPTION
it just update the old link https://thegraph.com/docs/define-a-subgraph to the graph docs on the subgraph demo page that its returning 404 now to the new one https://thegraph.com/docs/en/developer/create-subgraph-hosted

![image](https://user-images.githubusercontent.com/1799851/178970188-022898f4-6bc9-4479-8eb6-8972a05103c7.png)
