### PR TITLE
Add commas as thousand separators in wallet balance

### DIFF
--- a/packages/react-app/src/components/Balance.jsx
+++ b/packages/react-app/src/components/Balance.jsx
@@ -50,7 +50,7 @@ export default function Balance(props) {
   const price = props.price || props.dollarMultiplier || 1;
 
   if (dollarMode) {
-    displayBalance = "$" + (floatBalance * price).toFixed(2);
+    displayBalance = "$" + (floatBalance * price).toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 });
   }
 
   return (


### PR DESCRIPTION
Instead of showing $16242.33 it will show $16,242.33 in the wallet balance component. More helpful with larger sums.