### PR TITLE
Show the correct button copy & icon on the Contract component

### DIFF
--- a/packages/react-app/src/components/Contract/FunctionForm.jsx
+++ b/packages/react-app/src/components/Contract/FunctionForm.jsx
@@ -12,6 +12,8 @@ const getFunctionInputKey = (functionInfo, input, inputIndex) => {
   return functionInfo.name + "_" + name + "_" + input.type;
 };
 
+const isReadable = fn => fn.stateMutability === "view" || fn.stateMutability === "pure";
+
 export default function FunctionForm({ contractFunction, functionInfo, provider, gasPrice, triggerRefresh }) {
   const [form, setForm] = useState({});
   const [txValue, setTxValue] = useState();
@@ -166,12 +168,11 @@ export default function FunctionForm({ contractFunction, functionInfo, provider,
     }
   };
 
-  const buttonIcon =
-    functionInfo.type === "call" ? (
-      <Button style={{ marginLeft: -32 }}>Read📡</Button>
-    ) : (
-      <Button style={{ marginLeft: -32 }}>Send💸</Button>
-    );
+  const buttonIcon = isReadable(functionInfo) ? (
+    <Button style={{ marginLeft: -32 }}>Read📡</Button>
+  ) : (
+    <Button style={{ marginLeft: -32 }}>Send💸</Button>
+  );
   inputs.push(
     <div style={{ cursor: "pointer", margin: 2 }} key="goButton">
       <Input

--- a/packages/react-app/src/views/Subgraph.jsx
+++ b/packages/react-app/src/views/Subgraph.jsx
@@ -147,7 +147,11 @@ function Subgraph(props) {
           packages/subgraph/src
         </span>
         (learn more about subgraph definition{" "}
-        <a href="https://thegraph.com/docs/en/developer/define-subgraph-hosted/" target="_blank" rel="noopener noreferrer">
+        <a
+          href="https://thegraph.com/docs/en/developer/define-subgraph-hosted/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           here
         </a>
         )


### PR DESCRIPTION
There was some (non-working) display logic to show a different button copy & icon depending on the type of the contract call (read vs write txs). Read 📡 VS. Send💸

It was always showing the "send 💸" button.

It should be fixed now. It's just a little thing but I think it helps with the mental model (reads VS. write txs)

Before:
![3](https://user-images.githubusercontent.com/2486142/182867947-a8dc7c1c-0cb1-428e-a6cf-d5477c2e8e46.png)

After:
![4](https://user-images.githubusercontent.com/2486142/182868102-da60503b-ff54-4103-ac46-155706af19e6.png)

Also fixed some prettier warnings in the console.