### PR TITLE
delete file App.test.js from React-app

### DIFF
--- a/packages/react-app/src/App.test.js
+++ b/packages/react-app/src/App.test.js
@@ -1,9 +1,0 @@
-import React from "react";
-import { render } from "@testing-library/react";
-import App from "./App";
-
-test("renders learn react link", () => {
-  const { getByText } = render(<App />);
-  const linkElement = getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});


### PR DESCRIPTION
Delete testing template (added by create-react-app) which isn't designed to work with Scaffold-eth.

This template is more misleading than helpful atm. A better solution would be to adapt it to Scaffold. If it's needed, please reply in discussion what kind of adaptation would be merged, so that PR could be improved.