### PR TITLE
Add Infura IPFS Authentication for simple NFT example

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ yarn deploy --network NETWORK_OF_CHOICE (localhost, kovan, rinkeby, mainnet)
 
 ![nft1](https://user-images.githubusercontent.com/526558/124386962-37e5dd00-dcb3-11eb-911e-0afce760d7ee.png)
 
+
+> ✏️ Edit both `packages/hardhat/scripts/mint.js` and `packages/react-app/src/App.jsx` with your Infura project id and project secrets
+
+<img width="510" alt="image" src="https://user-images.githubusercontent.com/1975314/187358177-b9fc9c39-9e11-4384-aad8-6399b4f1e3dc.png">
+
+
+> ✏️ Edit the mint script mint.js in packages/hardhat/scripts and update the toAddress to your frontend address (wallet address in the top right or localhost:3000).
+
+
 > in a terminal window run the mint script:
 ```
 yarn mint

--- a/README.md
+++ b/README.md
@@ -41,9 +41,6 @@ yarn deploy --network NETWORK_OF_CHOICE (localhost, kovan, rinkeby, mainnet)
 <img width="510" alt="image" src="https://user-images.githubusercontent.com/1975314/187358177-b9fc9c39-9e11-4384-aad8-6399b4f1e3dc.png">
 
 
-> ✏️ Edit the mint script mint.js in packages/hardhat/scripts and update the toAddress to your frontend address (wallet address in the top right or localhost:3000).
-
-
 > in a terminal window run the mint script:
 ```
 yarn mint

--- a/packages/hardhat/scripts/mint.js
+++ b/packages/hardhat/scripts/mint.js
@@ -5,7 +5,18 @@ const { config, ethers } = require("hardhat");
 const { utils } = require("ethers");
 const R = require("ramda");
 const ipfsAPI = require('ipfs-http-client');
-const ipfs = ipfsAPI({host: 'ipfs.infura.io', port: '5001', protocol: 'https' })
+
+const projectId = 'YOUR INFURA PROJECT ID';
+const projectSecret = 'YOUR INFURA PROJECT SECRET';
+const auth = 'Basic ' + Buffer.from(projectId + ':' + projectSecret).toString('base64');
+const ipfs = ipfsAPI({
+  host: 'ipfs.infura.io', 
+  port: '5001', 
+  protocol: 'https', 
+  headers: {
+    authorization: auth,
+  }, 
+});
 
 const delayMS = 1000 //sometimes xDAI needs a 6000ms break lol 😅
 

--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -30,7 +30,17 @@ import {
 const { BufferList } = require("bl");
 // https://www.npmjs.com/package/ipfs-http-client
 const ipfsAPI = require("ipfs-http-client");
-const ipfs = ipfsAPI({ host: "ipfs.infura.io", port: "5001", protocol: "https" });
+const projectId = 'YOUR INFURA PROJECT ID';
+const projectSecret = 'YOUR INFURA PROJECT SECRET';
+const auth = 'Basic ' + Buffer.from(projectId + ':' + projectSecret).toString('base64');
+const ipfs = ipfsAPI({ 
+  host: "ipfs.infura.io", 
+  port: "5001", 
+  protocol: "https",
+  headers: {
+    authorization: auth,
+  },
+ });
 
 
 import { useContractConfig } from "./hooks"


### PR DESCRIPTION
Infura does not offer a public and free IPFS upload feature anymore, so you need to use project id and project secrets to authenticate 