### PR TITLE
Change order & replace 'deploy' with 'watch'

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,18 +25,18 @@ yarn install
 yarn chain
 ```
 
-> in a second terminal window, start your 📱 frontend:
+> in a second terminal window, 🛰 deploy your contract:
+
+```bash
+cd scaffold-eth
+yarn watch
+```
+
+> in a third terminal window, start your 📱 frontend:
 
 ```bash
 cd scaffold-eth
 yarn start
-```
-
-> in a third terminal window, 🛰 deploy your contract:
-
-```bash
-cd scaffold-eth
-yarn deploy
 ```
 
 🔏 Edit your smart contract `YourContract.sol` in `packages/hardhat/contracts`


### PR DESCRIPTION
1. It's better to deploy the contract before starting the app, because `yarn start` also opens the web browser, covering the terminal windows.
2. `.vscode/tasks.json` uses `yarn watch` instead of `yarn deploy` to deploy the contract, so it makes sense to also use that command here.