### PR TITLE
updated the logic to use no polling when on localhost and increased pollTime for mainnet calls

### DIFF
--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -30,7 +30,7 @@ import { NETWORKS, ALCHEMY_KEY } from "./constants";
 import externalContracts from "./contracts/external_contracts";
 // contracts
 import deployedContracts from "./contracts/hardhat_contracts.json";
-import { Transactor, Web3ModalSetup } from "./helpers";
+import { getRPCPollTime, Transactor, Web3ModalSetup } from "./helpers";
 import { Home, ExampleUI, Hints, Subgraph } from "./views";
 import { useStaticJsonRPC } from "./hooks";
 
@@ -84,8 +84,6 @@ function App(props) {
 
   const targetNetwork = NETWORKS[selectedNetwork];
 
-  const RPC_POLL_TIME = targetNetwork.rpcUrl === NETWORKS.localhost.rpcUrl ? 0 : LOCAL_RPC_POLL_TIME;
-
   // 🔭 block explorer URL
   const blockExplorer = targetNetwork.blockExplorer;
 
@@ -95,6 +93,9 @@ function App(props) {
   ]);
 
   const mainnetProvider = useStaticJsonRPC(providers, localProvider);
+
+  /* Can be passed to hooks which takes in pollTime, function `getRPCPollTime` gives you sensible pollTime depending on the provider you are using to decrease the number of rpc calls, checkout `getRPCPollTime` for more description. */
+  const RPC_POLL_TIME = getRPCPollTime(localProvider);
 
   if (DEBUG) console.log(`Using ${selectedNetwork} network`);
 

--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -1,5 +1,5 @@
 import { Button, Col, Menu, Row } from "antd";
-import { RPC_POLL_TIME } from "./constants";
+import { LOCAL_RPC_POLL_TIME, MAINNET_RPC_POLL_TIME } from "./constants";
 
 import "antd/dist/antd.css";
 import {
@@ -84,6 +84,8 @@ function App(props) {
 
   const targetNetwork = NETWORKS[selectedNetwork];
 
+  const RPC_POLL_TIME = targetNetwork.rpcUrl === NETWORKS.localhost.rpcUrl ? 0 : LOCAL_RPC_POLL_TIME;
+
   // 🔭 block explorer URL
   const blockExplorer = targetNetwork.blockExplorer;
 
@@ -113,7 +115,7 @@ function App(props) {
   const price = useExchangeEthPrice(targetNetwork, mainnetProvider, 1000);
 
   /* 🔥 This hook will get the price of Gas from ⛽️ EtherGasStation */
-  const gasPrice = useGasPrice(targetNetwork, "fast", RPC_POLL_TIME);
+  const gasPrice = useGasPrice(targetNetwork, "fast", LOCAL_RPC_POLL_TIME);
   // Use your injected provider from 🦊 Metamask or if you don't have it then instantly generate a 🔥 burner wallet.
   const userProviderAndSigner = useUserProviderAndSigner(injectedProvider, localProvider, USE_BURNER_WALLET);
   const userSigner = userProviderAndSigner.signer;
@@ -142,7 +144,7 @@ function App(props) {
   const yourLocalBalance = useBalance(localProvider, address, RPC_POLL_TIME);
 
   // Just plug in different 🛰 providers to get your balance on different chains:
-  const yourMainnetBalance = useBalance(mainnetProvider, address, RPC_POLL_TIME);
+  const yourMainnetBalance = useBalance(mainnetProvider, address, MAINNET_RPC_POLL_TIME);
 
   // const contractConfig = useContractConfig();
 
@@ -170,7 +172,7 @@ function App(props) {
     "DAI",
     "balanceOf",
     ["0x34aA3F359A9D614239015126635CE7732c18fDF3"],
-    RPC_POLL_TIME,
+    MAINNET_RPC_POLL_TIME,
   );
 
   // keep track of a variable from the contract in the local React state:

--- a/packages/react-app/src/components/Balance.jsx
+++ b/packages/react-app/src/components/Balance.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { useBalance } from "eth-hooks";
-import { LOCAL_RPC_POLL_TIME } from "../constants";
+import { getRPCPollTime } from "../helpers";
 
 const { utils } = require("ethers");
 
@@ -33,11 +33,7 @@ const { utils } = require("ethers");
 export default function Balance(props) {
   const [dollarMode, setDollarMode] = useState(true);
 
-  let RPC_POLL_TIME = LOCAL_RPC_POLL_TIME;
-
-  if (props.provider && props?.provider._network.chainId === 31337) {
-    RPC_POLL_TIME = 0;
-  }
+  let RPC_POLL_TIME = getRPCPollTime(props.provider);
 
   const balance = useBalance(props.provider, props.address, RPC_POLL_TIME);
   let floatBalance = parseFloat("0.00");

--- a/packages/react-app/src/components/Balance.jsx
+++ b/packages/react-app/src/components/Balance.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { useBalance } from "eth-hooks";
-import { RPC_POLL_TIME } from "../constants";
+import { LOCAL_RPC_POLL_TIME } from "../constants";
 
 const { utils } = require("ethers");
 
@@ -32,6 +32,12 @@ const { utils } = require("ethers");
 
 export default function Balance(props) {
   const [dollarMode, setDollarMode] = useState(true);
+
+  let RPC_POLL_TIME = LOCAL_RPC_POLL_TIME;
+
+  if (props.provider && props?.provider._network.chainId === 31337) {
+    RPC_POLL_TIME = 0;
+  }
 
   const balance = useBalance(props.provider, props.address, RPC_POLL_TIME);
   let floatBalance = parseFloat("0.00");

--- a/packages/react-app/src/components/FaucetHint.jsx
+++ b/packages/react-app/src/components/FaucetHint.jsx
@@ -4,10 +4,12 @@ import { ethers } from "ethers";
 import { useBalance, useGasPrice } from "eth-hooks";
 
 import { Transactor } from "../helpers";
-import { RPC_POLL_TIME } from "../constants";
+import { LOCAL_RPC_POLL_TIME } from "../constants";
 
 function FaucetHint({ localProvider, targetNetwork, address }) {
   const [faucetClicked, setFaucetClicked] = useState(false);
+
+  const RPC_POLL_TIME = localProvider && localProvider?._network.chainId === 31337 ? 0 : LOCAL_RPC_POLL_TIME;
 
   // fetch local balance
   const yourLocalBalance = useBalance(localProvider, address, RPC_POLL_TIME);

--- a/packages/react-app/src/components/FaucetHint.jsx
+++ b/packages/react-app/src/components/FaucetHint.jsx
@@ -3,13 +3,12 @@ import React, { useState } from "react";
 import { ethers } from "ethers";
 import { useBalance, useGasPrice } from "eth-hooks";
 
-import { Transactor } from "../helpers";
-import { LOCAL_RPC_POLL_TIME } from "../constants";
+import { getRPCPollTime, Transactor } from "../helpers";
 
 function FaucetHint({ localProvider, targetNetwork, address }) {
   const [faucetClicked, setFaucetClicked] = useState(false);
 
-  const RPC_POLL_TIME = localProvider && localProvider?._network.chainId === 31337 ? 0 : LOCAL_RPC_POLL_TIME;
+  const RPC_POLL_TIME = getRPCPollTime(localProvider);
 
   // fetch local balance
   const yourLocalBalance = useBalance(localProvider, address, RPC_POLL_TIME);

--- a/packages/react-app/src/components/TokenBalance.jsx
+++ b/packages/react-app/src/components/TokenBalance.jsx
@@ -2,13 +2,13 @@ import { useTokenBalance } from "eth-hooks/erc/erc-20/useTokenBalance";
 import React, { useState } from "react";
 
 import { utils } from "ethers";
-import { RPC_POLL_TIME } from "../constants";
+import { LOCAL_RPC_POLL_TIME } from "../constants";
 
 export default function TokenBalance(props) {
   const [dollarMode, setDollarMode] = useState(true);
 
   const tokenContract = props.contracts && props.contracts[props.name];
-  const balance = useTokenBalance(tokenContract, props.address, RPC_POLL_TIME);
+  const balance = useTokenBalance(tokenContract, props.address, LOCAL_RPC_POLL_TIME);
 
   let floatBalance = parseFloat("0.00");
 

--- a/packages/react-app/src/constants.js
+++ b/packages/react-app/src/constants.js
@@ -9,7 +9,11 @@ export const BLOCKNATIVE_DAPPID = "0b58206a-f3c0-4701-a62f-73c7243e8c77";
 
 export const ALCHEMY_KEY = "oKxs-03sij-U_N0iOlrSsZFr29-IqbuF";
 
-// LOCAL_RPC_POLL_TIME as 5 seconds to slower the rpc calls at start
+/* To decrease the number of RPC calls `LOCAL_RPC_POLL_TIME` is set to `5000ms` which can be passed to hooks which has pollTime like (useContractReader, useBalance etc) .
+
+NOTE : If you are not using local-hardhat chain and pass poolTime as 0 to hooks which uses pollTime they defaults to use `onBlock`. Checkout `src/hooks/useStaticJsonRPC.js` where provider pollingInterval is set to 30000ms i.e it will be checking for blocks after 30secs
+
+*/
 export const LOCAL_RPC_POLL_TIME = 5000;
 
 export const MAINNET_RPC_POLL_TIME = 30000;

--- a/packages/react-app/src/constants.js
+++ b/packages/react-app/src/constants.js
@@ -9,8 +9,10 @@ export const BLOCKNATIVE_DAPPID = "0b58206a-f3c0-4701-a62f-73c7243e8c77";
 
 export const ALCHEMY_KEY = "oKxs-03sij-U_N0iOlrSsZFr29-IqbuF";
 
-// RPC_POLL_TIME as 5 seconds to slower the rpc calls at start
-export const RPC_POLL_TIME = 5000;
+// LOCAL_RPC_POLL_TIME as 5 seconds to slower the rpc calls at start
+export const LOCAL_RPC_POLL_TIME = 5000;
+
+export const MAINNET_RPC_POLL_TIME = 30000;
 
 const localRpcUrl = process.env.REACT_APP_CODESPACES
   ? `https://${window.location.hostname.replace("3000", "8545")}`

--- a/packages/react-app/src/constants.js
+++ b/packages/react-app/src/constants.js
@@ -16,6 +16,7 @@ NOTE : If you are not using local-hardhat chain and pass poolTime as 0 to hooks 
 */
 export const LOCAL_RPC_POLL_TIME = 5000;
 
+// Similar to `LOCAL_RPC_POLL_TIME`, `MAINNET_RPC_POLL_TIME` can be used when you need to read value from ETH-Mainnet (eg reading mainnetBalance or MainnetDAIBalance)
 export const MAINNET_RPC_POLL_TIME = 30000;
 
 const localRpcUrl = process.env.REACT_APP_CODESPACES

--- a/packages/react-app/src/helpers/index.js
+++ b/packages/react-app/src/helpers/index.js
@@ -1,3 +1,4 @@
 export { default as Transactor } from "./Transactor";
 export { default as Web3ModalSetup } from "./Web3ModalSetup";
 export * as ipfs from "./ipfs";
+export * from "./rpc";

--- a/packages/react-app/src/helpers/rpc.js
+++ b/packages/react-app/src/helpers/rpc.js
@@ -1,0 +1,10 @@
+import { LOCAL_RPC_POLL_TIME } from "../constants";
+
+export const getRPCPollTime = provider => {
+  // If using local hardhat-chain then return pollInterval as 0 else set to 5000, checkout `LOCAL_RPC_POLL_TIME` for more description
+  if (provider && provider._network.chainId === 31337) {
+    return 0;
+  } else {
+    return LOCAL_RPC_POLL_TIME;
+  }
+};

--- a/packages/react-app/src/hooks/useStaticJsonRPC.js
+++ b/packages/react-app/src/hooks/useStaticJsonRPC.js
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { ethers } from "ethers";
+import { NETWORKS } from "../constants";
 
 const createProvider = async url => {
   const p = new ethers.providers.StaticJsonRpcProvider(url);
@@ -17,8 +18,10 @@ export default function useStaticJsonRPC(urlArray, localProvider = null) {
       const p = await Promise.race(urlArray.map(createProvider));
       const _p = await p;
 
-      // set localProviders internal polling interval
-      _p.pollingInterval = 50000;
+      if (urlArray[0] !== NETWORKS.localhost.rpcUrl) {
+        // set localProviders internal polling interval, if its not localhost
+        _p.pollingInterval = 50000;
+      }
 
       setProvider(_p);
     } catch (error) {

--- a/packages/react-app/src/hooks/useStaticJsonRPC.js
+++ b/packages/react-app/src/hooks/useStaticJsonRPC.js
@@ -20,7 +20,7 @@ export default function useStaticJsonRPC(urlArray, localProvider = null) {
 
       if (urlArray[0] !== NETWORKS.localhost.rpcUrl) {
         // set localProviders internal polling interval, if its not localhost
-        _p.pollingInterval = 50000;
+        _p.pollingInterval = 30000;
       }
 
       setProvider(_p);


### PR DESCRIPTION
## <u> **Current situation #896 :** </u>
- When you send funds through the faucet it takes around `5 sec` to reflect since `RPC_POLL_TIME = 5000` which I think is a bit slow for local development.

- If you try setting `purpose` through the `ExampleUI` tab it again takes `5 sec` to update the purpose which is slow. 

- Another problem is let's suppose a builder creates a new `Contract` and tries to read from the contract  using `useContractReader` hook and fails to pass `pollInterval` in arguments, Now if the value updates it will take **`50 sec`** to reflect that in `UI` due to ` _p.pollingInterval = 50000;` in `useStaticJsonRPC.js`. Since `useContractReader` updates the values when new block is added when `pollInterval` argument is not passed or it is passed as `0` and since `_p.pollingInterval` is set to `50000` it will check for new block after `50000` .

-  In `App.jsx`,  `yourMainnetBalance` and `myMainnetDAIBalance` are using `Mainnet RPC`,  having `pollTime` of `5 sec` 
and this is only used to show the usage of `hooks` and are only `console.logged` in `useEffect`. It creates a load on `Mainnet RPC` used .

## <u> **Proposed Solution :** </u>
- Update the logic in `useStaticJsonRPC.js` to not use ` _p.pollingInterval = 50000;` when using `localhost` also updated `RPC_POLL_TIME` variable wherever used to be `0` when you are on `localhost`. This helps the ui reflect quickly .

- Increased the `PollTime` for `yourMainnetBalance` and `myMainnetDAIBalance` which decreases the request to `Mainneet RPC's` by around `7-8` **`calls per min`**
  PS : Created a constant `MAINNET_RPC_POOL_TIME`, Instead we can directly put in value as parameter.

## Some before and after SS of number of calls in around a min : 

### Before : 

All Fetch/XHR Calls            |  Showing only calls to Mainnet(Filtered using domain)
:-------------------------:|:-------------------------------------------------------:
![Screenshot 2022-09-27 at 4 49 20 PM](https://user-images.githubusercontent.com/80153681/192534865-58697680-ce13-482e-92b5-565e85eb8ea8.jpg) |  ![Screenshot 2022-09-27 at 4 44 49 PM](https://user-images.githubusercontent.com/80153681/192535539-e6066395-f97d-4943-b130-40812949e061.jpg)

## After Changes : 

All Fetch/XHR Calls            |  Showing only calls to Mainnet(Filtered using domain)
:-------------------------:|:-------------------------------------------------------:
![Screenshot 2022-09-27 at 4 54 14 PM 1](https://user-images.githubusercontent.com/80153681/192536763-db9cd7ea-0cc9-419b-92f1-024f9b9eed72.jpg) |  ![Screenshot 2022-09-27 at 4 56 53 PM](https://user-images.githubusercontent.com/80153681/192536809-10cfd1de-1d4b-4b2f-a5f3-700b4397297e.jpg)

PS : I think we should decrease the ` _p.pollingInterval = 50000;` to `30000` i.e around 2 blocks or maybe we can mention somewhere to decrease `_p.pollingInterval = 50000;` because if someone uses `useContractReader` without passing  Pollinterval argument and using chain other than `localchain`, he/she will find it hard to debug like I barely anytime time pass pollInterval to `useContractReader` but I may be wrong 😅. 

Sorry for my bad explanations 😅 , would try my best to explain again if there are any doubts 🙌