### PR TITLE
Make `setPurpose` function payable for fixing revert function on ExampleUI interactions

### DIFF
--- a/packages/hardhat/contracts/YourContract.sol
+++ b/packages/hardhat/contracts/YourContract.sol
@@ -15,7 +15,7 @@ contract YourContract {
     // what should we do on deploy?
   }
 
-  function setPurpose(string memory newPurpose) public {
+  function setPurpose(string memory newPurpose) public payable {
       purpose = newPurpose;
       console.log(msg.sender,"set purpose to",purpose);
       emit SetPurpose(msg.sender, purpose);


### PR DESCRIPTION
On the sample smart contract `YourContract` we have the function `setPurpose`. When we interact with the ExampleUI we can call this function with ETH value which makes the transaction revert, when we perform `Set Purpose With Value`action.

This PR changes the function `setPurpose` to payable.

**Before**

[non-payable-function.webm](https://user-images.githubusercontent.com/54408225/194826386-f8bf6361-0c87-4df2-a830-54072dd9a0c3.webm)


**After**

[Screencast from 09-10-22 12:54:53.webm](https://user-images.githubusercontent.com/54408225/194752884-9b364cf7-8d09-4571-9aa1-fa40cc72ec4b.webm)
