### PR TITLE
927 update default network address

### DIFF
--- a/packages/hardhat/hardhat.config.js
+++ b/packages/hardhat/hardhat.config.js
@@ -59,7 +59,7 @@ module.exports = {
 
   networks: {
     localhost: {
-      url: "http://localhost:8545",
+      url: "http://127.0.0.1:8545/",
       /*
         notice no mnemonic here? it will just use account 0 of the hardhat node to deploy
         (you can put in a mnemonic here to set the deployer locally)


### PR DESCRIPTION
This updates the default address for localhost in the hardhat-config.js file due to yarn deploy failing.

Should close #927 

![Screenshot 2022-12-27 at 9 51 07 PM](https://user-images.githubusercontent.com/9419140/209749809-9b814aea-330f-4703-bba8-efe8b522ab87.png)
