### PR TITLE
Fix blockExplorerUrl error when adding a localhost network

### DIFF
--- a/packages/react-app/src/components/NetworkDisplay.jsx
+++ b/packages/react-app/src/components/NetworkDisplay.jsx
@@ -43,13 +43,15 @@ function NetworkDisplay({
                 <Button
                   onClick={async () => {
                     const ethereum = window.ethereum;
+                    const blockExplorerUrls = targetNetwork.blockExplorer ? [targetNetwork.blockExplorer] : undefined;
+
                     const data = [
                       {
                         chainId: "0x" + targetNetwork.chainId.toString(16),
                         chainName: targetNetwork.name,
                         nativeCurrency: targetNetwork.nativeCurrency,
                         rpcUrls: [targetNetwork.rpcUrl],
-                        blockExplorerUrls: [targetNetwork.blockExplorer],
+                        blockExplorerUrls,
                       },
                     ];
                     console.log("data", data);
@@ -67,6 +69,7 @@ function NetworkDisplay({
                         switchTx = await ethereum.request({
                           method: "wallet_addEthereumChain",
                           params: data,
+                          blockExplorerUrls,
                         });
                       } catch (addError) {
                         // handle "add" error

--- a/packages/react-app/src/constants.js
+++ b/packages/react-app/src/constants.js
@@ -31,6 +31,11 @@ export const NETWORKS = {
     chainId: 31337,
     blockExplorer: "",
     rpcUrl: localRpcUrl,
+    nativeCurrency: {
+      name: "ETH",
+      symbol: "ETH",
+      decimals: 18,
+    },
   },
   mainnet: {
     name: "mainnet",


### PR DESCRIPTION
Hello there.

I've connected my Metamask to the frontend to do some testing but have failed to switch to "localhost" network using this button. It has failed for Coinbase Wallet either.
<img width="470" alt="CleanShot 2023-03-07 at 13 35 38@2x" src="https://user-images.githubusercontent.com/37555845/223341246-f086434b-53f4-4ed4-9b6f-1565c2c4d0e3.png">
<img width="888" alt="CleanShot 2023-03-07 at 13 42 54@2x" src="https://user-images.githubusercontent.com/37555845/223343815-b2468e20-e608-4fbe-9e9d-ffd274d4ee58.png">

### The bug

So the bug can be described as: 
> As long you don't have a network `localhost:8545` with `chainId: 31337` added to your wallet, you won't be able to use this button to add or switch networks.

Steps to reproduce: 
1. Remove `localhost:8545` network from your wallet if it exists.
2. Press the `You have mainnet selected and you need to be on [localhost]`  button.
3. Check the console

Also, I think it is connected with https://github.com/scaffold-eth/scaffold-eth/issues/482. The feature was implemented but hasn't been working for the case described.

https://user-images.githubusercontent.com/37555845/223353714-33e53b54-2d70-477a-8df9-59d9e6dd7042.mp4

### The solution
The error message is `Expected null or array with at least one valid string HTTPS URL 'blockExplorerUrl'. Received: "}`.
So the root of the problem is in the constants.js file, [NETWORKS.localhost.blockExplorer](https://github.com/scaffold-eth/scaffold-eth/blob/master/packages/react-app/src/constants.js#L32).

This empty string is the only element of the `blockExplorerUrls` array that will be passed in the `ethereum.request` parameters. And, according to the docs ([EIP-3326](https://eips.ethereum.org/EIPS/eip-3326), [Metamask](https://docs.metamask.io/guide/rpc-api.html#unrestricted-methods), [Coinbase](https://docs.cloud.coinbase.com/wallet-sdk/docs/switching-chains#switching-or-adding-alternative-evm-compatible-chains))

`targetNetwork.blockExplorer` must be checked for emptiness before use. In case of an empty string `undefined` must be passed to `blockExplorerUrls`instead of `['']`

https://user-images.githubusercontent.com/37555845/223355661-6ff34424-003e-4159-8a0b-02127ff5734d.mp4