### PR TITLE
Fix for the graph-node service not to crash with the v0.30.0+ docker image

### DIFF
--- a/packages/services/graph-node/docker-compose.yml
+++ b/packages/services/graph-node/docker-compose.yml
@@ -36,5 +36,7 @@ services:
       POSTGRES_USER: graph-node
       POSTGRES_PASSWORD: let-me-in
       POSTGRES_DB: graph-node
+      PGDATA: "/var/lib/postgresql/data"
+      POSTGRES_INITDB_ARGS: "-E UTF8 --locale=C"
     volumes:
       - ./data/postgres:/var/lib/postgresql/data


### PR DESCRIPTION
## Problem
After pulling a fresh graph-node image, the service won't start with the current docker-compose. 

To reproduce the issue with an existing graph-node service
- `docker-compose pull` to pick up the latest image,
- `mv data data.bak` to move aside the existing data volume.

## Cause
From the [graph-node v0.30.0 release notes](https://github.com/graphprotocol/graph-node/blob/master/NEWS.md#database-locale-change)
> New graph-node installations now mandate PostgreSQL to use C locale and UTF-8 encoding. The official docker-compose.yml template has been updated accordingly. Pre-existing graph-node installations are not concerned with this change, but local development scripts and CI pipelines may have to adjust database initialization parameters. This can be done with initdb -E UTF8 --locale=C. https://github.com/graphprotocol/graph-node/pull/4163, https://github.com/graphprotocol/graph-node/pull/4151, https://github.com/graphprotocol/graph-node/pull/4201, https://github.com/graphprotocol/graph-node/pull/4340

## Solution
Update [docker-compose.yml](packages/services/graph-node/docker-compose.yml) to track the upstream file, particularly [the changes L46-47](https://github.com/graphprotocol/graph-node/blob/5fa50f987187530cd551aad3c4496350c5832081/docker/docker-compose.yml#L46-L47).

Changes:
- The `POSTGRES_INITDB_ARGS` env variable addresses [the PostgreSQL change](https://github.com/graphprotocol/graph-node/pull/4151/files).
- The `PGDATA` env variable addresses [another issue affecting MacOS M1 users](https://github.com/graphprotocol/graph-node/pull/3511).
