### PR TITLE
Update SE-2 repo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ---
 
-🎖 Scaffold-ETH 2 is the latest version of this developer experience, we recommend you fork: https://github.com/scaffold-eth/se-2
+🎖 Scaffold-ETH 2 is the latest version of this developer experience, we recommend you fork: https://github.com/scaffold-eth/scaffold-eth-2
 
 ---
 


### PR DESCRIPTION
We changed the repo name: se-2 => scaffold-eth-2.

Redirection works, but let's better have the new URL.